### PR TITLE
fix: imbot excludes

### DIFF
--- a/.imgbotconfig.json
+++ b/.imgbotconfig.json
@@ -1,0 +1,9 @@
+{
+  "schedule": "weekly",
+  "ignoredFiles": [
+    "public/images/overlay/*"
+  ],
+  "aggressiveCompression": "false",
+  "compressWiki": "false",
+  "minKBReduced": 500
+}


### PR DESCRIPTION
Config file for imgbot to exclude overlay-images, unsure if those settings are ok?

Docs: https://imgbot.net/docs/