### PR TITLE
Update changelog nav item icon

### DIFF
--- a/src/components/Dashboard/navigation.tsx
+++ b/src/components/Dashboard/navigation.tsx
@@ -5,7 +5,7 @@ import {
   CommandLineIcon,
   HeartIcon,
   QuestionMarkCircleIcon,
-  RssIcon,
+  NewspaperIcon,
   GlobeEuropeAfricaIcon,
   MegaphoneIcon,
   ScaleIcon,
@@ -120,6 +120,6 @@ export const navigation = [
   {
     name: 'Changelog',
     href: 'https://discord.com/channels/1039887907705593876/1069124160179163146',
-    icon: RssIcon,
+    icon: NewspaperIcon,
   },
 ]


### PR DESCRIPTION
Replaces the RSS icon with a Newspaper icon for the changelog nav item in the dashboard navigation to better represent the content.

- Updates the import in `src/components/Dashboard/navigation.tsx` to replace `RssIcon` with `NewspaperIcon` from `@heroicons/react/24/outline`.
- Changes the icon for the 'Changelog' nav item to use the `NewspaperIcon`, making it more relevant to the changelog content.

Closes #100

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/dotabod/frontend?shareId=aa7fe51c-30b2-4903-b246-9f7943dd099d).