### PR TITLE
fix: Update MinimapBlocker.tsx

### DIFF
--- a/src/components/Overlay/blocker/MinimapBlocker.tsx
+++ b/src/components/Overlay/blocker/MinimapBlocker.tsx
@@ -27,7 +27,7 @@ export const OriginalMinimapBlocker = ({ block }: { block: blockType }) => {
               w: 280,
             })
           : res({
-              w: 240,
+              w: 244,
             })
       }
       height={
@@ -36,7 +36,7 @@ export const OriginalMinimapBlocker = ({ block }: { block: blockType }) => {
               h: 280,
             })
           : res({
-              h: 240,
+              h: 244,
             })
       }
       src={`/images/overlay/minimap/738-${isSimple ? 'Simple' : 'Complex'}-${


### PR DESCRIPTION
I saw some misalignments on twitch. For 1080p default should be 244x244 and large 280x280. I think?