### PR TITLE
Fix typo in SubscriptionBadge comment

### DIFF
--- a/src/components/Dashboard/SubscriptionBadge.tsx
+++ b/src/components/Dashboard/SubscriptionBadge.tsx
@@ -114,7 +114,7 @@ export const SubscriptionBadge = ({ collapsed }: { collapsed: boolean }) => {
   const badgeDetails = getSubscriptionBadge()
 
   // logo for lifetime is https://cdn.betterttv.net/emote/609431bc39b5010444d0cbdc/3x.webp
-  // otehrwise its the current plan logo
+  // otherwise its the current plan logo
   const logo =
     currentPlan?.tier === 'PRO' && subscription?.transactionType === 'LIFETIME' ? (
       <Image


### PR DESCRIPTION
## Summary
- correct "otehrwise" typo in SubscriptionBadge comment

## Testing
- `bun run test` *(fails: vitest: command not found)*