### PR TITLE
Add real timers cleanup for GiftSubscriptionAlert test

### DIFF
--- a/src/__tests__/components/Overlay/GiftAlert/GiftSubscriptionAlert.test.tsx
+++ b/src/__tests__/components/Overlay/GiftAlert/GiftSubscriptionAlert.test.tsx
@@ -8,6 +8,8 @@ describe('GiftSubscriptionAlert', () => {
   })
 
   afterEach(() => {
+    vi.useRealTimers()
+    vi.clearAllTimers()
     vi.restoreAllMocks()
     cleanup()
   })


### PR DESCRIPTION
## Summary
- restore timers in GiftSubscriptionAlert tests to avoid lingering mocks

## Testing
- `bun run test` *(fails: vitest: command not found)*