### PR TITLE
Add lint/test CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,19 @@
+name: Lint and Test
+
+on:
+  push:
+    branches: ['**']
+  pull_request:
+    branches: ['**']
+
+jobs:
+  lint_and_test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: 'latest'
+      - run: bun install --frozen-lockfile
+      - run: bun run lint
+      - run: bun run test


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to run lint and test on pushes and PRs

## Testing
- `bun run test` *(fails: Script not found "vitest")*