### PR TITLE
Add Biome Lefthook and CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: biomejs/setup-biome@v2
+        with:
+          version: latest
+      - uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: latest
+      - name: Install dependencies
+        run: bun install --no-progress --frozen-lockfile
+      - name: Run Biome
+        run: biome ci .
+      - name: Run tests
+        run: bun run test

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,8 @@
+pre-commit:
+  commands:
+    biome:
+      run: npx @biomejs/biome check --no-errors-on-unmatched --files-ignore-unknown=true --colors=off {staged_files}
+pre-push:
+  commands:
+    biome:
+      run: npx @biomejs/biome check --no-errors-on-unmatched --files-ignore-unknown=true --colors=off {push_files}

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "test": "bun run vitest",
     "test:watch": "bun run vitest watch",
     "test:coverage": "NODE_OPTIONS='--max-old-space-size=4096' bun run vitest run --coverage",
+    "prepare": "lefthook install",
     "generate:postgres": "bun prisma generate",
     "generate:mongo": "bun prisma generate --schema=./prisma-mongo/schema.prisma",
     "generate:all": "bun run generate:postgres && bun run generate:mongo",
@@ -104,7 +105,8 @@
     "postcss": "^8.5.3",
     "prisma": "^6.6.0",
     "typescript": "^5.8.3",
-    "vitest": "^3.1.1"
+    "vitest": "^3.1.1",
+    "lefthook": "^1.5.8"
   },
   "trustedDependencies": [
     "@biomejs/biome",


### PR DESCRIPTION
## Summary
- run biome checks on pre-commit and pre-push via lefthook
- install lefthook automatically via `prepare` script
- add lefthook as a dev dependency
- run Biome and tests in CI using GitHub Actions

## Testing
- `npx @biomejs/biome ci .` *(fails: connect EHOSTUNREACH)*
- `bun run test` *(fails: Script not found "vitest")*