### PR TITLE
Add gift credit refund clarification

### DIFF
--- a/src/pages/terms-of-service.tsx
+++ b/src/pages/terms-of-service.tsx
@@ -429,6 +429,13 @@ const TermsOfService: NextPageWithLayout = () => (
           price changes to you in accordance with applicable law.
         </div>
         <br />
+        <div>
+          <strong>Gifted Credits</strong>
+        </div>
+        <div>
+          Gift subscriptions and other gifted credits extend the recipient's access to Dotabod Pro but are not refundable.
+        </div>
+        <br />
         <div id='prohibited'>
           <strong>7. PROHIBITED ACTIVITIES</strong>
         </div>


### PR DESCRIPTION
## Summary
- clarify that gift credits extend Dotabod Pro access but are non‑refundable

## Testing
- `bun run lint` *(fails: biome not found)*
- `bun run test` *(fails: vitest not installed)*