### PR TITLE
Add minimap opacity control

### DIFF
--- a/features.md
+++ b/features.md
@@ -29,6 +29,7 @@ Semi-transparent blocker that auto places itself over your minimap to deter peop
 - Right side minimap
 - Battlepass hud
 - Complex minimap option
+- Minimap opacity control
 
 ## Picks
 

--- a/src/components/Billing/BillingPlans.tsx
+++ b/src/components/Billing/BillingPlans.tsx
@@ -69,6 +69,7 @@ export const plans = [
       'Auto twitch predictions for each match',
       'Pro commands (!hero, !np, !items, !gm, !smurfs)',
       'Advanced overlays (XL Minimap, Anti-snipe blockers)',
+      'Minimap blocker intensity control',
       'Notable players overlay with flags',
       'Win probability overlay with !wp command',
       'Stream delay customization',

--- a/src/components/Dashboard/Features/MinimapCard.tsx
+++ b/src/components/Dashboard/Features/MinimapCard.tsx
@@ -4,6 +4,7 @@ import { Card } from '@/ui/card'
 import clsx from 'clsx'
 import Image from 'next/image'
 import { TierBadge } from './TierBadge'
+import { TierNumber } from './TierNumber'
 import { TierSwitch } from './TierSwitch'
 
 export default function MinimapCard(): React.ReactNode {
@@ -92,6 +93,16 @@ export default function MinimapCard(): React.ReactNode {
             <span>Simple minimap</span>
           </div>
         </div>
+      </div>
+
+      <div className='mt-6'>
+        <TierNumber
+          settingKey={Settings['minimap-opacity']}
+          min={0}
+          max={1}
+          step={0.05}
+          label='Minimap opacity'
+        />
       </div>
     </Card>
   )

--- a/src/components/Dashboard/Features/MinimapCard.tsx
+++ b/src/components/Dashboard/Features/MinimapCard.tsx
@@ -1,13 +1,13 @@
 import { Settings } from '@/lib/defaultSettings'
 import { useUpdateSetting } from '@/lib/hooks/useUpdateSetting'
 import { Card } from '@/ui/card'
+import { Tag } from 'antd'
 import clsx from 'clsx'
 import Image from 'next/image'
-import { useState, useEffect } from 'react'
+import { useEffect, useState } from 'react'
 import { TierBadge } from './TierBadge'
 import { TierSlider } from './TierSlider'
 import { TierSwitch } from './TierSwitch'
-import { Tag } from 'antd'
 
 export default function MinimapCard(): React.ReactNode {
   const { data: isEnabled } = useUpdateSetting(Settings['minimap-blocker'])
@@ -56,18 +56,18 @@ export default function MinimapCard(): React.ReactNode {
   // Get description text based on opacity value
   const getOpacityDescription = () => {
     if (localOpacity >= 0.95) {
-      return "Maximum protection: Minimap completely hidden from viewers"
+      return 'Maximum protection: Minimap completely hidden from viewers'
     }
     if (localOpacity >= 0.75) {
-      return "High protection: Most minimap details are hidden from viewers"
+      return 'High protection: Most minimap details are hidden from viewers'
     }
     if (localOpacity >= 0.5) {
-      return "Medium protection: Some minimap details visible but wards are hidden"
+      return 'Medium protection: Some minimap details visible but wards are hidden'
     }
     if (localOpacity >= 0.25) {
       return "Optimal setting: Chat can see hero positions but snipers can't see wards"
     }
-    return "Low protection: Minimap is mostly visible to viewers"
+    return 'Low protection: Minimap is mostly visible to viewers'
   }
 
   return (
@@ -93,9 +93,9 @@ export default function MinimapCard(): React.ReactNode {
           max={1}
           step={0.05}
           label={
-            <span className="flex items-center gap-2">
+            <span className='flex items-center gap-2'>
               Blocker intensity
-              <Tag color="green">New</Tag>
+              <Tag color='green'>New</Tag>
             </span>
           }
           onChange={handleOpacityChange}
@@ -127,7 +127,6 @@ export default function MinimapCard(): React.ReactNode {
           <span>Complex minimap</span>
         </div>
 
-
         <div className='flex flex-col items-center space-y-4'>
           <Image
             className={clsx(
@@ -149,7 +148,6 @@ export default function MinimapCard(): React.ReactNode {
           </div>
         </div>
       </div>
-
     </Card>
   )
 }

--- a/src/components/Dashboard/Features/MinimapCard.tsx
+++ b/src/components/Dashboard/Features/MinimapCard.tsx
@@ -3,14 +3,27 @@ import { useUpdateSetting } from '@/lib/hooks/useUpdateSetting'
 import { Card } from '@/ui/card'
 import clsx from 'clsx'
 import Image from 'next/image'
+import { useState, useEffect } from 'react'
 import { TierBadge } from './TierBadge'
-import { TierNumber } from './TierNumber'
+import { TierSlider } from './TierSlider'
 import { TierSwitch } from './TierSwitch'
+import { Tag } from 'antd'
 
 export default function MinimapCard(): React.ReactNode {
   const { data: isEnabled } = useUpdateSetting(Settings['minimap-blocker'])
   const { data: minimapSimple } = useUpdateSetting(Settings['minimap-simple'])
   const { data: minimapXl } = useUpdateSetting(Settings['minimap-xl'])
+  const { data: minimapOpacity } = useUpdateSetting<number>(Settings['minimap-opacity'])
+
+  // Local state for real-time opacity preview
+  const [localOpacity, setLocalOpacity] = useState<number>(minimapOpacity ?? 1)
+
+  // Update local opacity when the setting changes
+  useEffect(() => {
+    if (minimapOpacity !== undefined) {
+      setLocalOpacity(minimapOpacity)
+    }
+  }, [minimapOpacity])
 
   const switches = [
     {
@@ -35,6 +48,28 @@ export default function MinimapCard(): React.ReactNode {
     },
   ]
 
+  // Handle opacity changes from the slider
+  const handleOpacityChange = (value: number) => {
+    setLocalOpacity(value)
+  }
+
+  // Get description text based on opacity value
+  const getOpacityDescription = () => {
+    if (localOpacity >= 0.95) {
+      return "Maximum protection: Minimap completely hidden from viewers"
+    }
+    if (localOpacity >= 0.75) {
+      return "High protection: Most minimap details are hidden from viewers"
+    }
+    if (localOpacity >= 0.5) {
+      return "Medium protection: Some minimap details visible but wards are hidden"
+    }
+    if (localOpacity >= 0.25) {
+      return "Optimal setting: Chat can see hero positions but snipers can't see wards"
+    }
+    return "Low protection: Minimap is mostly visible to viewers"
+  }
+
   return (
     <Card>
       <div className='title'>
@@ -51,6 +86,22 @@ export default function MinimapCard(): React.ReactNode {
           ))}
         </div>
       </div>
+      <div className='mb-6'>
+        <TierSlider
+          settingKey={Settings['minimap-opacity']}
+          min={0}
+          max={1}
+          step={0.05}
+          label={
+            <span className="flex items-center gap-2">
+              Blocker intensity
+              <Tag color="green">New</Tag>
+            </span>
+          }
+          onChange={handleOpacityChange}
+          helpText={getOpacityDescription()}
+        />
+      </div>
 
       <div
         className={clsx(
@@ -65,6 +116,7 @@ export default function MinimapCard(): React.ReactNode {
               minimapSimple && 'opacity-60',
               'rounded-xl border-2 border-transparent transition-all',
             )}
+            style={{ opacity: localOpacity }}
             alt='minimap blocker'
             width={minimapXl ? 280 : 240}
             height={minimapXl ? 280 : 240}
@@ -74,6 +126,8 @@ export default function MinimapCard(): React.ReactNode {
           />
           <span>Complex minimap</span>
         </div>
+
+
         <div className='flex flex-col items-center space-y-4'>
           <Image
             className={clsx(
@@ -81,6 +135,7 @@ export default function MinimapCard(): React.ReactNode {
               !minimapSimple && 'opacity-60',
               'rounded-xl border-2 border-transparent transition-all',
             )}
+            style={{ opacity: localOpacity }}
             alt='minimap blocker'
             width={minimapXl ? 280 : 240}
             height={minimapXl ? 280 : 240}
@@ -95,15 +150,6 @@ export default function MinimapCard(): React.ReactNode {
         </div>
       </div>
 
-      <div className='mt-6'>
-        <TierNumber
-          settingKey={Settings['minimap-opacity']}
-          min={0}
-          max={1}
-          step={0.05}
-          label='Minimap opacity'
-        />
-      </div>
     </Card>
   )
 }

--- a/src/components/Dashboard/Features/TierNumber.tsx
+++ b/src/components/Dashboard/Features/TierNumber.tsx
@@ -1,0 +1,64 @@
+import type { SettingKeys } from '@/lib/defaultSettings'
+import { useUpdateSetting } from '@/lib/hooks/useUpdateSetting'
+import type { ChatterSettingKeys } from '@/utils/subscription'
+import { InputNumber, type InputNumberProps } from 'antd'
+import { TierBadge } from './TierBadge'
+
+interface TierNumberProps extends Omit<InputNumberProps, 'onChange'> {
+  settingKey: SettingKeys | ChatterSettingKeys
+  label?: React.ReactNode
+  className?: string
+  onChange?: (value: number | null) => void
+  helpText?: string
+  hideTierBadge?: boolean
+}
+
+export function TierNumber({
+  settingKey,
+  label,
+  className,
+  hideTierBadge,
+  disabled: externalDisabled,
+  value: externalValue,
+  onChange: externalOnChange,
+  helpText,
+  ...inputProps
+}: TierNumberProps) {
+  const { data: rawValue, updateSetting, tierAccess } = useUpdateSetting<number>(settingKey)
+
+  const isDisabled = externalDisabled || !tierAccess.hasAccess
+  const numberValue = externalValue ?? rawValue
+
+  const handleChange = (value: number | null) => {
+    if (externalOnChange) {
+      externalOnChange(value)
+    } else {
+      if (typeof value === 'number') updateSetting(value)
+    }
+  }
+
+  const inputId = `input-${settingKey}`
+
+  return (
+    <div className={`space-y-1 ${className ?? ''}`}>
+      {label && (
+        <label htmlFor={inputId} className='block text-sm'>
+          {label}
+          {!tierAccess.hasAccess && !hideTierBadge && (
+            <span className='ml-2'>
+              <TierBadge requiredTier={tierAccess.requiredTier} />
+            </span>
+          )}
+        </label>
+      )}
+      <InputNumber
+        id={inputId}
+        value={numberValue}
+        onChange={handleChange}
+        disabled={isDisabled}
+        {...inputProps}
+      />
+      {helpText && <span className='block text-xs italic'>{helpText}</span>}
+    </div>
+  )
+}

--- a/src/components/Dashboard/Features/TierSlider.tsx
+++ b/src/components/Dashboard/Features/TierSlider.tsx
@@ -1,0 +1,102 @@
+import type { SettingKeys } from '@/lib/defaultSettings'
+import { useUpdateSetting } from '@/lib/hooks/useUpdateSetting'
+import type { ChatterSettingKeys } from '@/utils/subscription'
+import { Slider, type SliderSingleProps } from 'antd'
+import { useEffect, useState } from 'react'
+import { TierBadge } from './TierBadge'
+
+interface TierSliderProps extends Omit<SliderSingleProps, 'onChange'> {
+  settingKey: SettingKeys | ChatterSettingKeys
+  label?: React.ReactNode
+  className?: string
+  onChange?: (value: number) => void
+  helpText?: string
+  hideTierBadge?: boolean
+  debounceMs?: number
+}
+
+export function TierSlider({
+  settingKey,
+  label,
+  className,
+  hideTierBadge,
+  disabled: externalDisabled,
+  value: externalValue,
+  onChange: externalOnChange,
+  helpText,
+  debounceMs = 500, // Default debounce of 500ms
+  ...sliderProps
+}: TierSliderProps) {
+  const { data: rawValue, updateSetting, tierAccess } = useUpdateSetting<number>(settingKey)
+  const [localValue, setLocalValue] = useState<number>(externalValue ?? rawValue ?? 0)
+  const [debounceTimeout, setDebounceTimeout] = useState<NodeJS.Timeout | null>(null)
+
+  const isDisabled = externalDisabled || !tierAccess.hasAccess
+
+  // Update local value when external value changes
+  useEffect(() => {
+    if (externalValue !== undefined) {
+      setLocalValue(externalValue)
+    } else if (rawValue !== undefined) {
+      setLocalValue(rawValue)
+    }
+  }, [externalValue, rawValue])
+
+  const handleChange = (value: number) => {
+    setLocalValue(value)
+
+    // If external onChange is provided, call it immediately
+    if (externalOnChange) {
+      externalOnChange(value)
+    } else {
+      // Otherwise debounce the updateSetting call
+      if (debounceTimeout) {
+        clearTimeout(debounceTimeout)
+      }
+
+      const newTimeout = setTimeout(() => {
+        updateSetting(value)
+      }, debounceMs)
+
+      setDebounceTimeout(newTimeout)
+    }
+  }
+
+  // Clean up timeout on unmount
+  useEffect(() => {
+    return () => {
+      if (debounceTimeout) {
+        clearTimeout(debounceTimeout)
+      }
+    }
+  }, [debounceTimeout])
+
+  const sliderId = `slider-${settingKey}`
+
+  return (
+    <div className={`space-y-1 ${className ?? ''}`}>
+      {label && (
+        <div className="flex items-center">
+          <label htmlFor={sliderId} className='block text-sm'>
+            {label}
+          </label>
+          {!tierAccess.hasAccess && !hideTierBadge && (
+            <span className='ml-2'>
+              <TierBadge requiredTier={tierAccess.requiredTier} />
+            </span>
+          )}
+        </div>
+      )}
+      <div className="py-2">
+        <Slider
+          id={sliderId}
+          value={localValue}
+          onChange={handleChange}
+          disabled={isDisabled}
+          {...sliderProps}
+        />
+      </div>
+      {helpText && <span className='block text-xs italic'>{helpText}</span>}
+    </div>
+  )
+}

--- a/src/components/Dashboard/Features/TierSlider.tsx
+++ b/src/components/Dashboard/Features/TierSlider.tsx
@@ -76,7 +76,7 @@ export function TierSlider({
   return (
     <div className={`space-y-1 ${className ?? ''}`}>
       {label && (
-        <div className="flex items-center">
+        <div className='flex items-center'>
           <label htmlFor={sliderId} className='block text-sm'>
             {label}
           </label>
@@ -87,7 +87,7 @@ export function TierSlider({
           )}
         </div>
       )}
-      <div className="py-2">
+      <div className='py-2'>
         <Slider
           id={sliderId}
           value={localValue}

--- a/src/components/Dashboard/navigation.tsx
+++ b/src/components/Dashboard/navigation.tsx
@@ -53,6 +53,7 @@ export const navigation = [
       {
         name: 'Overlay',
         href: '/dashboard/features/overlay',
+        new: true,
       },
       {
         name: 'Chat',
@@ -61,7 +62,6 @@ export const navigation = [
       {
         name: 'Notable Players',
         href: '/dashboard/notable-players',
-        new: true,
       },
       {
         name: 'Advanced',

--- a/src/components/Overlay/blocker/MinimapBlocker.tsx
+++ b/src/components/Overlay/blocker/MinimapBlocker.tsx
@@ -13,6 +13,7 @@ import Minimap from '../minimap'
 const OriginalMinimapBlocker = ({ block }: { block: blockType }) => {
   const { data: isSimple } = useUpdateSetting(Settings['minimap-simple'])
   const { data: isXL } = useUpdateSetting(Settings['minimap-xl'])
+  const { data: opacityLevel } = useUpdateSetting<number>(Settings['minimap-opacity'])
   const res = useTransformRes({ returnInput: false })
 
   return (
@@ -42,6 +43,9 @@ const OriginalMinimapBlocker = ({ block }: { block: blockType }) => {
       src={`/images/overlay/minimap/738-${isSimple ? 'Simple' : 'Complex'}-${
         isXL ? 'X' : ''
       }Large-AntiStreamSnipeMap.png`}
+      style={{
+        opacity: opacityLevel ?? 0.25,
+      }}
     />
   )
 }

--- a/src/components/Overlay/minimap/index.tsx
+++ b/src/components/Overlay/minimap/index.tsx
@@ -21,6 +21,7 @@ function Minimap({ block }: { block: blockType }) {
   const { data: isSimple } = useUpdateSetting(Settings['minimap-simple'])
   const { data: isXL } = useUpdateSetting(Settings['minimap-xl'])
   const { data: isRight } = useUpdateSetting(Settings.minimapRight)
+  const { data: fogOpacity } = useUpdateSetting<number>(Settings['minimap-opacity'])
 
   const isPreview = useSelector(selectIsPreview)
   const settings = useSelector(selectSettings)
@@ -46,7 +47,7 @@ function Minimap({ block }: { block: blockType }) {
           isPreview ? preview : '',
         ].join(' ')}
       >
-        <div className={fog} />
+        <div className={fog} style={{ ['--minimap-opacity' as any]: fogOpacity }} />
 
         {buildings.map((building, index) => (
           <Building team={block?.team} data={building} key={`minimap-building-${index}`} />

--- a/src/lib/defaultSettings.ts
+++ b/src/lib/defaultSettings.ts
@@ -126,6 +126,7 @@ export const defaultSettings = {
   rosh: true,
   'minimap-simple': false,
   'minimap-xl': false,
+  'minimap-opacity': 0.25,
   onlyParty: false,
   livePolls: true,
   streamDelay: 0,

--- a/src/lib/theme/themeConfig.ts
+++ b/src/lib/theme/themeConfig.ts
@@ -34,6 +34,15 @@ const themeConfig: ThemeConfig = {
       colorPrimaryHover: 'var(--color-purple-300)',
       colorPrimaryActive: 'var(--color-purple-300)',
     },
+    Slider: {
+      trackBg: 'rgb(107, 33, 168)',
+      trackHoverBg: 'rgb(126, 34, 206)',
+      handleColor: 'white',
+      handleActiveColor: 'white',
+      railBg: 'rgba(255, 255, 255, 0.25)',
+      railHoverBg: 'rgba(255, 255, 255, 0.35)',
+      dotBorderColor: 'rgb(107, 33, 168)',
+    },
   },
   token: {
     colorPrimary: 'rgb(85, 24, 103)',

--- a/src/lib/validations/setting.ts
+++ b/src/lib/validations/setting.ts
@@ -82,6 +82,7 @@ const settingsSchema = {
   rosh: z.boolean(),
   'minimap-simple': z.boolean(),
   'minimap-xl': z.boolean(),
+  'minimap-opacity': z.number().min(0).max(1),
   onlyParty: z.boolean(),
   livePolls: z.boolean(),
   streamDelay: z.number().min(0).max(300000),

--- a/src/styles/tailwind.css
+++ b/src/styles/tailwind.css
@@ -355,9 +355,9 @@
 }
 
 .fog {
-	width: 100%;
-	height: 100%;
-	background: rgba(0, 0, 0, 0.25);
+        width: 100%;
+        height: 100%;
+        background: rgba(0, 0, 0, var(--minimap-opacity, 0.25));
 }
 
 .container-creep {

--- a/src/utils/subscription.ts
+++ b/src/utils/subscription.ts
@@ -93,6 +93,7 @@ export const FEATURE_TIERS: Record<SettingKeys | ChatterSettingKeys, Subscriptio
   livePolls: SUBSCRIPTION_TIERS.PRO,
   'minimap-simple': SUBSCRIPTION_TIERS.PRO,
   'minimap-xl': SUBSCRIPTION_TIERS.FREE,
+  'minimap-opacity': SUBSCRIPTION_TIERS.PRO,
   notablePlayersOverlay: SUBSCRIPTION_TIERS.PRO,
   notablePlayersOverlayFlags: SUBSCRIPTION_TIERS.PRO,
   notablePlayersOverlayFlagsCmd: SUBSCRIPTION_TIERS.PRO,


### PR DESCRIPTION
## Summary
- allow adjusting minimap opacity with a new `minimap-opacity` setting
- validate and persist the new setting
- support the feature in subscription tiers
- expose opacity slider in dashboard
- apply CSS variable for minimap fog
- document new feature

closes https://github.com/dotabod/frontend/issues/35

## Testing
- `bun run lint`
- `bun run typecheck` *(fails: Cannot find module '@prisma/client')*
- `bun run test` *(fails: Cannot find package '@vitejs/plugin-react')*