### PR TITLE
Refactor Stripe handlers into services

### DIFF
--- a/src/__tests__/services/gift-service.test.ts
+++ b/src/__tests__/services/gift-service.test.ts
@@ -1,0 +1,25 @@
+import { stripe } from '@/lib/stripe-server'
+import { GiftService } from '@/pages/api/stripe/services/gift-service'
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/lib/stripe-server', () => ({
+  stripe: {
+    checkout: { sessions: { list: vi.fn().mockResolvedValue({ data: [] }) } },
+    customers: { createBalanceTransaction: vi.fn() },
+  },
+}))
+
+const tx: any = {
+  user: { findUnique: vi.fn() },
+  giftTransaction: { findFirst: vi.fn() },
+  subscription: { updateMany: vi.fn() },
+}
+
+describe('GiftService.processGiftRefund', () => {
+  it('returns early when no refund amount', async () => {
+    const service = new GiftService(tx)
+    const charge: any = { amount_refunded: 0 }
+    await service.processGiftRefund(charge)
+    expect(stripe.checkout.sessions.list).not.toHaveBeenCalled()
+  })
+})

--- a/src/__tests__/services/subscription-service.test.ts
+++ b/src/__tests__/services/subscription-service.test.ts
@@ -1,0 +1,17 @@
+import { SubscriptionService } from '@/pages/api/stripe/services/subscription-service'
+import { SubscriptionStatus } from '@prisma/client'
+import { describe, expect, it } from 'vitest'
+
+describe('SubscriptionService.mapStripeStatus', () => {
+  it('maps active status', () => {
+    expect(SubscriptionService.mapStripeStatus('active')).toBe(SubscriptionStatus.ACTIVE)
+  })
+
+  it('maps trialing status', () => {
+    expect(SubscriptionService.mapStripeStatus('trialing')).toBe(SubscriptionStatus.TRIALING)
+  })
+
+  it('maps unknown status to canceled', () => {
+    expect(SubscriptionService.mapStripeStatus('unknown')).toBe(SubscriptionStatus.CANCELED)
+  })
+})

--- a/src/pages/api/stripe/handlers/charge-events.ts
+++ b/src/pages/api/stripe/handlers/charge-events.ts
@@ -1,7 +1,8 @@
 import { stripe } from '@/lib/stripe-server'
 import type { Prisma } from '@prisma/client'
-import { SubscriptionStatus, TransactionType } from '@prisma/client'
 import type Stripe from 'stripe'
+import { GiftService } from '../services/gift-service'
+import { SubscriptionService } from '../services/subscription-service'
 import { withErrorHandling } from '../utils/error-handling'
 import {
   createLifetimePurchase,
@@ -173,10 +174,11 @@ export async function handleChargeRefunded(
     return (
       (await withErrorHandling(
         async () => {
-          await handleGiftCreditRefund(charge, tx)
+          const giftService = new GiftService(tx)
+          await giftService.processGiftRefund(charge)
           return true
         },
-        `handleGiftCreditRefund(${charge.id})`,
+        `GiftService.processGiftRefund(${charge.id})`,
         charge.metadata?.gifterId || 'system',
       )) !== null
     )
@@ -189,8 +191,8 @@ export async function handleChargeRefunded(
     return (
       (await withErrorHandling(
         async () => {
-          // Process subscription updates for any subscription type
-          await processSubscriptionRefund(userId, charge, tx)
+          const subscriptionService = new SubscriptionService(tx)
+          await subscriptionService.processRefund(userId, charge)
           return true
         },
         `handleChargeRefunded(${charge.id})`,
@@ -207,7 +209,8 @@ export async function handleChargeRefunded(
         async () => {
           // Try to determine if this was a gift payment and handle accordingly
           if (await isGiftPayment(charge.payment_intent as string)) {
-            await handleGiftCreditRefund(charge, tx)
+            const giftService = new GiftService(tx)
+            await giftService.processGiftRefund(charge)
             return true
           }
 
@@ -215,8 +218,8 @@ export async function handleChargeRefunded(
           const userId = await getUserIdFromPaymentIntent(charge.payment_intent as string, tx)
           if (userId) {
             console.log(`Found userId ${userId} from payment intent lookup`)
-            // Process the refund with the retrieved userId
-            await processSubscriptionRefund(userId, charge, tx)
+            const subscriptionService = new SubscriptionService(tx)
+            await subscriptionService.processRefund(userId, charge)
             return true
           }
 
@@ -255,215 +258,6 @@ async function isGiftPayment(paymentIntentId: string): Promise<boolean> {
 /**
  * Handles a gift credit refund by reversing the customer balance credit
  * @param charge The Stripe charge object with refund information
- * @param tx The transaction client
- */
-async function handleGiftCreditRefund(
-  charge: Stripe.Charge,
-  tx: Prisma.TransactionClient,
-): Promise<void> {
-  // Only process full or partial refunds
-  if (charge.amount_refunded <= 0) {
-    console.log(`Skipping charge ${charge.id}: no refund amount`)
-    return
-  }
-
-  // Find the checkout session associated with this charge
-  const paymentIntent = typeof charge.payment_intent === 'string' ? charge.payment_intent : null
-
-  if (!paymentIntent) {
-    console.log(`Skipping charge ${charge.id}: no string payment intent`)
-    return
-  }
-
-  console.log(`Looking up checkout session for payment intent ${paymentIntent}`)
-  const sessions = await stripe.checkout.sessions.list({
-    payment_intent: paymentIntent,
-    limit: 1,
-  })
-
-  if (sessions.data.length === 0) {
-    console.log(`No checkout session found for payment intent ${paymentIntent}`)
-    return
-  }
-
-  const session = sessions.data[0]
-  console.log(`Found checkout session ${session.id} for payment intent ${paymentIntent}`)
-
-  // Verify this is a gift
-  if (session.metadata?.isGift !== 'true') {
-    console.log(`Checkout session ${session.id} is not a gift`)
-    return
-  }
-
-  const recipientUserId = session.metadata?.recipientUserId
-  if (!recipientUserId) {
-    console.log(`Checkout session ${session.id} has no recipientUserId`)
-    return
-  }
-
-  // Find the recipient's customer ID
-  const user = await tx.user.findUnique({
-    where: { id: recipientUserId },
-    include: {
-      subscription: {
-        where: {
-          stripeCustomerId: { not: null },
-        },
-        orderBy: { createdAt: 'desc' },
-        take: 1,
-      },
-    },
-  })
-
-  const customerId = user?.subscription[0]?.stripeCustomerId
-  if (!customerId) {
-    console.log(`No Stripe customer ID found for user ${recipientUserId}`)
-    return
-  }
-
-  console.log(
-    `Processing gift credit refund for recipient ${recipientUserId} with customer ${customerId}`,
-  )
-
-  // Look for the gift transaction record in our database
-  const giftTransaction = await tx.giftTransaction.findFirst({
-    where: {
-      OR: [
-        { metadata: { path: ['checkoutSessionId'], equals: session.id } },
-        { metadata: { path: ['paymentIntentId'], equals: paymentIntent } },
-        { stripeSessionId: session.id },
-      ],
-    },
-    include: {
-      giftSubscription: true,
-    },
-  })
-
-  if (giftTransaction) {
-    console.log(`Found gift transaction record ${giftTransaction.id} for refund`)
-
-    // Calculate the refund amount as a positive number for the reversal
-    // If it's a partial refund, calculate the proportion of the credit to reverse
-    const originalAmount = giftTransaction.amount
-    const refundProportion = charge.amount_refunded / charge.amount
-    const refundAmount = Math.round(originalAmount * refundProportion)
-
-    console.log(
-      `Calculated refund amount: ${refundAmount} (${refundProportion * 100}% of ${originalAmount})`,
-    )
-
-    try {
-      // Record the refund in our gift transaction
-      await tx.giftTransaction.update({
-        where: { id: giftTransaction.id },
-        data: {
-          updatedAt: new Date(),
-          metadata: {
-            ...((giftTransaction.metadata as Record<string, unknown>) || {}),
-            refundedAt: new Date().toISOString(),
-            refundAmount: refundAmount.toString(),
-            refundProportion: refundProportion.toString(),
-            refundId: charge.refunds?.data?.[0]?.id || null,
-          },
-        },
-      })
-
-      // For customer balance credits, create a positive balance transaction to offset the credit
-      // This effectively "cancels out" the original negative credit amount
-      const balanceTransaction = await stripe.customers.createBalanceTransaction(customerId, {
-        amount: refundAmount, // Positive amount to reverse the credit
-        currency: giftTransaction.currency,
-        description: `Refund of gift credit from ${giftTransaction.giftSubscription?.senderName || 'Anonymous'}`,
-        metadata: {
-          originalTransactionId: giftTransaction.id,
-          refundId: charge.refunds?.data?.[0]?.id || null,
-          refundedAt: new Date().toISOString(),
-          isRefund: 'true',
-        },
-      })
-
-      console.log(
-        `Successfully created balance transaction ${balanceTransaction.id} to reverse gift credit`,
-      )
-
-      // If this was a full refund, also mark the gift subscription record as canceled
-      if (charge.refunded && giftTransaction.giftSubscriptionId) {
-        await tx.subscription.updateMany({
-          where: {
-            giftDetails: {
-              id: giftTransaction.giftSubscriptionId,
-            },
-          },
-          data: {
-            status: SubscriptionStatus.CANCELED,
-            updatedAt: new Date(),
-            metadata: {
-              refundedAt: new Date().toISOString(),
-              refundId: charge.refunds?.data?.[0]?.id || null,
-            },
-          },
-        })
-
-        console.log(
-          `Marked gift subscription ${giftTransaction.giftSubscriptionId} as canceled due to refund`,
-        )
-      }
-    } catch (error) {
-      console.error('Error processing gift credit refund:', error)
-      throw error // Rethrow to be caught by withErrorHandling
-    }
-  } else {
-    console.log(`No gift transaction record found for refund of checkout ${session.id}`)
-
-    // Create a basic reversal based on session metadata
-    if (customerId && session.metadata?.giftType && session.metadata?.giftQuantity) {
-      try {
-        const giftType = session.metadata.giftType
-        const giftQuantity = Number.parseInt(session.metadata.giftQuantity, 10) || 1
-
-        // Calculate an approximate refund amount based on standard pricing
-        const priceMap = {
-          monthly:
-            Number.parseInt(process.env.MONTHLY_SUBSCRIPTION_PRICE_CENTS || '500', 10) *
-            giftQuantity,
-          annual:
-            Number.parseInt(process.env.ANNUAL_SUBSCRIPTION_PRICE_CENTS || '4800', 10) *
-            giftQuantity,
-          lifetime:
-            Number.parseInt(process.env.LIFETIME_SUBSCRIPTION_PRICE_CENTS || '30000', 10) *
-            giftQuantity,
-        }
-
-        const refundAmount = priceMap[giftType as keyof typeof priceMap] || 0
-        const refundProportion = charge.amount_refunded / charge.amount
-        const finalRefundAmount = Math.round(refundAmount * refundProportion)
-
-        console.log(`Calculated estimated refund amount: ${finalRefundAmount}`)
-
-        if (finalRefundAmount > 0) {
-          const balanceTransaction = await stripe.customers.createBalanceTransaction(customerId, {
-            amount: finalRefundAmount,
-            currency: 'usd',
-            description: `Refund of estimated gift credit from ${session.metadata.giftSenderName || 'Anonymous'}`,
-            metadata: {
-              checkoutSessionId: session.id,
-              paymentIntentId: paymentIntent,
-              refundId: charge.refunds?.data?.[0]?.id || null,
-              refundedAt: new Date().toISOString(),
-              isRefund: 'true',
-              isEstimated: 'true',
-            },
-          })
-
-          console.log(`Created estimated balance transaction ${balanceTransaction.id} for refund`)
-        } else {
-          console.log('Could not calculate a valid refund amount, skipping balance transaction')
-        }
-      } catch (error) {
-        console.error('Error creating estimated balance transaction for refund:', error)
-      }
-    }
-  }
 }
 
 /**
@@ -529,116 +323,5 @@ async function getUserIdFromPaymentIntent(
   } catch (error) {
     console.error(`Error retrieving userId from payment intent ${paymentIntentId}:`, error)
     return null
-  }
-}
-
-/**
- * Processes subscription updates for a refund
- * @param userId The user ID associated with the refund
- * @param charge The Stripe charge object with refund information
- * @param tx The transaction client
- */
-async function processSubscriptionRefund(
-  userId: string,
-  charge: Stripe.Charge,
-  tx: Prisma.TransactionClient,
-): Promise<void> {
-  // Get all active subscriptions for this user/customer
-  const subscriptions = await tx.subscription.findMany({
-    where: {
-      userId,
-      stripeCustomerId: charge.customer as string,
-    },
-  })
-
-  if (subscriptions.length === 0) {
-    console.log(`No subscriptions found for user ${userId} with customer ${charge.customer}`)
-    return
-  }
-
-  // Log what we found
-  console.log(`Found ${subscriptions.length} subscriptions to update for refund`)
-
-  // Update each subscription based on the refund
-  for (const subscription of subscriptions) {
-    // For lifetime or one-time purchases, handle refunds by updating status
-    if (subscription.transactionType === TransactionType.LIFETIME) {
-      // If fully refunded, mark the purchase as canceled
-      if (charge.refunded) {
-        await tx.subscription.update({
-          where: { id: subscription.id },
-          data: {
-            status: SubscriptionStatus.CANCELED,
-            updatedAt: new Date(),
-            metadata: {
-              ...((subscription.metadata as Record<string, unknown>) || {}),
-              refundedAt: new Date().toISOString(),
-              refundAmount: charge.amount_refunded > 0 ? charge.amount_refunded.toString() : null,
-              refundId: charge.refunds?.data?.[0]?.id || null,
-            },
-          },
-        })
-        console.log(
-          `Marked ${subscription.transactionType} subscription ${subscription.id} as canceled due to full refund`,
-        )
-      }
-      // If partially refunded, update the metadata
-      else if (charge.amount_refunded > 0) {
-        await tx.subscription.update({
-          where: { id: subscription.id },
-          data: {
-            updatedAt: new Date(),
-            metadata: {
-              ...((subscription.metadata as Record<string, unknown>) || {}),
-              partiallyRefundedAt: new Date().toISOString(),
-              refundAmount: charge.amount_refunded.toString(),
-              refundId: charge.refunds?.data?.[0]?.id || null,
-            },
-          },
-        })
-        console.log(
-          `Updated ${subscription.transactionType} subscription ${subscription.id} metadata for partial refund`,
-        )
-      }
-    }
-    // For crypto payments, we need to manually cancel them since Stripe won't handle it through subscription webhooks
-    else if (
-      (subscription.metadata as Record<string, unknown>)?.isCryptoPayment === 'true' &&
-      charge.refunded
-    ) {
-      await tx.subscription.update({
-        where: { id: subscription.id },
-        data: {
-          status: SubscriptionStatus.CANCELED,
-          updatedAt: new Date(),
-          metadata: {
-            ...((subscription.metadata as Record<string, unknown>) || {}),
-            refundedAt: new Date().toISOString(),
-            refundAmount: charge.amount_refunded > 0 ? charge.amount_refunded.toString() : null,
-            refundId: charge.refunds?.data?.[0]?.id || null,
-            fullyRefunded: 'true',
-          },
-        },
-      })
-      console.log(`Manually canceled crypto subscription ${subscription.id} due to refund`)
-    }
-    // For recurring subscriptions, just record the refund in metadata
-    // The actual subscription status changes will come from Stripe subscription webhooks
-    else if (subscription.status !== SubscriptionStatus.CANCELED) {
-      await tx.subscription.update({
-        where: { id: subscription.id },
-        data: {
-          updatedAt: new Date(),
-          metadata: {
-            ...((subscription.metadata as Record<string, unknown>) || {}),
-            refundRecorded: new Date().toISOString(),
-            refundAmount: charge.amount_refunded > 0 ? charge.amount_refunded.toString() : null,
-            refundId: charge.refunds?.data?.[0]?.id || null,
-            fullyRefunded: charge.refunded ? 'true' : 'false',
-          },
-        },
-      })
-      console.log(`Updated recurring subscription ${subscription.id} metadata for refund`)
-    }
   }
 }

--- a/src/pages/api/stripe/handlers/invoice-events.ts
+++ b/src/pages/api/stripe/handlers/invoice-events.ts
@@ -1,6 +1,7 @@
 import { stripe } from '@/lib/stripe-server'
 import { type Prisma, SubscriptionStatus } from '@prisma/client'
 import type Stripe from 'stripe'
+import { SubscriptionService } from '../services/subscription-service'
 import { withErrorHandling } from '../utils/error-handling'
 import {
   createCryptoSubscription,
@@ -45,7 +46,7 @@ export async function handleInvoiceEvent(
         if (!userId) return false
 
         // Map Stripe status to our internal status
-        const status = mapStripeStatus(subscription.status)
+        const status = SubscriptionService.mapStripeStatus(subscription.status)
         const currentPeriodEnd = new Date(subscription.items.data[0]?.current_period_end * 1000)
 
         // Update the subscription record with the latest status
@@ -342,26 +343,6 @@ async function handleCryptoInvoiceEvent(
  * @param status The Stripe subscription status
  * @returns The mapped status
  */
-function mapStripeStatus(status: string): SubscriptionStatus {
-  switch (status) {
-    case 'active':
-      return SubscriptionStatus.ACTIVE
-    case 'trialing':
-      return SubscriptionStatus.TRIALING
-    case 'past_due':
-      return SubscriptionStatus.PAST_DUE
-    case 'canceled':
-      return SubscriptionStatus.CANCELED
-    case 'unpaid':
-      return SubscriptionStatus.PAST_DUE
-    case 'incomplete':
-      return SubscriptionStatus.PAST_DUE
-    case 'incomplete_expired':
-      return SubscriptionStatus.CANCELED
-    default:
-      return SubscriptionStatus.CANCELED
-  }
-}
 
 /**
  * Handles a Boomfi crypto invoice.paid event

--- a/src/pages/api/stripe/services/subscription-service.ts
+++ b/src/pages/api/stripe/services/subscription-service.ts
@@ -1,0 +1,117 @@
+import { type Prisma, SubscriptionStatus, TransactionType } from '@prisma/client'
+import type Stripe from 'stripe'
+import { withErrorHandling } from '../utils/error-handling'
+
+/** Service for subscription related operations */
+export class SubscriptionService {
+  constructor(private tx: Prisma.TransactionClient) {}
+
+  /**
+   * Maps Stripe subscription status to internal status
+   */
+  static mapStripeStatus(status: string): SubscriptionStatus {
+    switch (status) {
+      case 'active':
+        return SubscriptionStatus.ACTIVE
+      case 'trialing':
+        return SubscriptionStatus.TRIALING
+      case 'past_due':
+        return SubscriptionStatus.PAST_DUE
+      case 'canceled':
+        return SubscriptionStatus.CANCELED
+      case 'unpaid':
+      case 'incomplete':
+        return SubscriptionStatus.PAST_DUE
+      case 'incomplete_expired':
+        return SubscriptionStatus.CANCELED
+      default:
+        return SubscriptionStatus.CANCELED
+    }
+  }
+
+  /**
+   * Update subscriptions when a charge is refunded
+   */
+  async processRefund(userId: string, charge: Stripe.Charge): Promise<void> {
+    await withErrorHandling(
+      async () => {
+        const subscriptions = await this.tx.subscription.findMany({
+          where: {
+            userId,
+            stripeCustomerId: charge.customer as string,
+          },
+        })
+
+        for (const subscription of subscriptions) {
+          if (subscription.transactionType === TransactionType.LIFETIME) {
+            if (charge.refunded) {
+              await this.tx.subscription.update({
+                where: { id: subscription.id },
+                data: {
+                  status: SubscriptionStatus.CANCELED,
+                  updatedAt: new Date(),
+                  metadata: {
+                    ...((subscription.metadata as Record<string, unknown>) || {}),
+                    refundedAt: new Date().toISOString(),
+                    refundAmount:
+                      charge.amount_refunded > 0 ? charge.amount_refunded.toString() : null,
+                    refundId: charge.refunds?.data?.[0]?.id || null,
+                  },
+                },
+              })
+            } else if (charge.amount_refunded > 0) {
+              await this.tx.subscription.update({
+                where: { id: subscription.id },
+                data: {
+                  updatedAt: new Date(),
+                  metadata: {
+                    ...((subscription.metadata as Record<string, unknown>) || {}),
+                    partiallyRefundedAt: new Date().toISOString(),
+                    refundAmount: charge.amount_refunded.toString(),
+                    refundId: charge.refunds?.data?.[0]?.id || null,
+                  },
+                },
+              })
+            }
+          } else if (
+            (subscription.metadata as Record<string, unknown>)?.isCryptoPayment === 'true' &&
+            charge.refunded
+          ) {
+            await this.tx.subscription.update({
+              where: { id: subscription.id },
+              data: {
+                status: SubscriptionStatus.CANCELED,
+                updatedAt: new Date(),
+                metadata: {
+                  ...((subscription.metadata as Record<string, unknown>) || {}),
+                  refundedAt: new Date().toISOString(),
+                  refundAmount:
+                    charge.amount_refunded > 0 ? charge.amount_refunded.toString() : null,
+                  refundId: charge.refunds?.data?.[0]?.id || null,
+                  fullyRefunded: 'true',
+                },
+              },
+            })
+          } else if (subscription.status !== SubscriptionStatus.CANCELED) {
+            await this.tx.subscription.update({
+              where: { id: subscription.id },
+              data: {
+                updatedAt: new Date(),
+                metadata: {
+                  ...((subscription.metadata as Record<string, unknown>) || {}),
+                  refundRecorded: new Date().toISOString(),
+                  refundAmount:
+                    charge.amount_refunded > 0 ? charge.amount_refunded.toString() : null,
+                  refundId: charge.refunds?.data?.[0]?.id || null,
+                  fullyRefunded: charge.refunded ? 'true' : 'false',
+                },
+              },
+            })
+          }
+        }
+      },
+      `SubscriptionService.processRefund(${charge.id})`,
+      userId,
+    )
+  }
+}

--- a/src/pages/api/stripe/services/webhook-service.ts
+++ b/src/pages/api/stripe/services/webhook-service.ts
@@ -1,0 +1,40 @@
+import { stripe } from '@/lib/stripe-server'
+import type { NextApiRequest } from 'next'
+import type Stripe from 'stripe'
+import { debugLog } from '../utils/debugLog'
+
+export async function verifyWebhook(
+  req: NextApiRequest,
+): Promise<{ event?: Stripe.Event; error?: string }> {
+  debugLog('Entering verifyWebhook')
+  const signature = req.headers['stripe-signature'] as string
+  const webhookSecret = process.env.STRIPE_WEBHOOK_SECRET
+
+  if (!signature || !webhookSecret) {
+    debugLog('Missing signature or webhook secret')
+    return { error: 'Webhook configuration error' }
+  }
+
+  try {
+    debugLog('Getting raw body')
+    const rawBody = await getRawBody(req)
+    debugLog('Constructing webhook event')
+    const event = stripe.webhooks.constructEvent(rawBody, signature, webhookSecret)
+    debugLog('Webhook event constructed successfully', { eventId: event.id })
+    debugLog('Exiting verifyWebhook successfully')
+    return { event }
+  } catch (err) {
+    console.error('Webhook verification failed:', err)
+    debugLog('Webhook verification failed', { error: err })
+    debugLog('Exiting verifyWebhook with error')
+    return { error: 'Webhook verification failed' }
+  }
+}
+
+async function getRawBody(req: NextApiRequest): Promise<string> {
+  const chunks: Uint8Array[] = []
+  for await (const chunk of req) {
+    chunks.push(typeof chunk === 'string' ? Buffer.from(chunk) : chunk)
+  }
+  return Buffer.concat(chunks).toString()
+}


### PR DESCRIPTION
## Summary
- extract subscription handling into a service module
- move webhook verification to its own service
- expose gift refund logic through the gift service
- simplify checkout handler to reuse CustomerService
- update charge and invoice handlers to use the new services
- add unit tests for service helpers

## Testing
- `bun run lint`
- `bun run test` *(fails: Cannot find package '@vitejs/plugin-react')*