### PR TITLE
fix: align chatter patch example with current Dota patch

### DIFF
--- a/src/components/Dashboard/Features/ChatterCard.tsx
+++ b/src/components/Dashboard/Features/ChatterCard.tsx
@@ -324,7 +324,7 @@ export const chatterInfo = {
           src='https://static-cdn.jtvnw.net/emoticons/v2/305954156/default/dark/2.0'
         />
         <span>
-          A new Dota 2 patch has been released: 7.38c. Check out the patch notes at
+          A new Dota 2 patch has been released: 7.41. Check out the patch notes at
           https://www.dota2.com/patches
         </span>
       </span>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- audited frontend for references potentially stale after backend PR #580 timing updates
- confirmed no frontend contract changes are required for roshan/aegis/midas/neutral events
- updated the sample `dotapatch` chatter message from `7.38c` to `7.41` to avoid displaying outdated patch info

## Validation
- searched frontend source for old neutral tier timing references and patch literals
- reviewed overlay socket/event handling for payload-shape dependencies and found no incompatibilities with backend PR #580

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e67fb195-2618-4383-bbd0-c973a4ba6e82"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e67fb195-2618-4383-bbd0-c973a4ba6e82"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

