### PR TITLE
fix: resolve GitHub Actions Biome failures

### DIFF
--- a/src/components/Billing/PeriodToggle.tsx
+++ b/src/components/Billing/PeriodToggle.tsx
@@ -17,6 +17,7 @@ interface PeriodToggleProps {
 
 export function PeriodToggle({ activePeriod, onChange, subscription }: PeriodToggleProps) {
   const periods: PricePeriod[] = ['monthly', 'annual', 'lifetime']
+  const radioGroupName = 'billing-period'
 
   // Set initial period based on subscription
   useEffect(() => {
@@ -27,33 +28,35 @@ export function PeriodToggle({ activePeriod, onChange, subscription }: PeriodTog
   }, [subscription, onChange])
 
   return (
-    <div
-      role='radiogroup'
-      aria-label='Billing period'
-      className='flex flex-col sm:grid sm:grid-cols-3 rounded-lg'
-    >
+    <fieldset className='flex flex-col sm:grid sm:grid-cols-3 rounded-lg'>
+      <legend className='sr-only'>Billing period</legend>
       {periods.map((period) => (
         <div
           key={period}
           className={clsx('relative py-1.5 sm:py-0 sm:flex sm:flex-col', 'sm:min-h-[3.5rem]')}
         >
-          <button
-            type='button'
-            role='radio'
-            aria-checked={activePeriod === period}
-            tabIndex={activePeriod === period ? 0 : -1}
-            onClick={() => onChange(period)}
-            className={clsx(
-              'bg-gray-800/50 cursor-pointer px-3 sm:px-4 md:px-8 py-2 text-sm transition-colors rounded-md',
-              'w-full flex items-center justify-center',
-              'focus:outline-hidden focus:ring-2 focus:ring-purple-500 focus:ring-offset-2 focus:ring-offset-gray-900',
-              activePeriod === period
-                ? 'bg-purple-500 text-gray-900 font-semibold shadow-lg'
-                : 'text-gray-300 hover:bg-gray-700/50',
-            )}
-          >
-            <span className='first-letter:uppercase'>{period}</span>
-          </button>
+          <label className='block'>
+            <input
+              type='radio'
+              name={radioGroupName}
+              value={period}
+              checked={activePeriod === period}
+              onChange={() => onChange(period)}
+              className='peer sr-only'
+            />
+            <span
+              className={clsx(
+                'bg-gray-800/50 cursor-pointer px-3 sm:px-4 md:px-8 py-2 text-sm transition-colors rounded-md',
+                'flex w-full items-center justify-center',
+                'peer-focus-visible:outline-hidden peer-focus-visible:ring-2 peer-focus-visible:ring-purple-500 peer-focus-visible:ring-offset-2 peer-focus-visible:ring-offset-gray-900',
+                activePeriod === period
+                  ? 'bg-purple-500 text-gray-900 font-semibold shadow-lg'
+                  : 'text-gray-300 hover:bg-gray-700/50',
+              )}
+            >
+              <span className='first-letter:uppercase'>{period}</span>
+            </span>
+          </label>
 
           <div
             className={clsx(
@@ -72,6 +75,6 @@ export function PeriodToggle({ activePeriod, onChange, subscription }: PeriodTog
           </div>
         </div>
       ))}
-    </div>
+    </fieldset>
   )
 }

--- a/src/components/Dashboard/ObsSetup.tsx
+++ b/src/components/Dashboard/ObsSetup.tsx
@@ -573,7 +573,7 @@ const ObsSetup: React.FC = () => {
           )}
 
           {/* Show version recommendation alert if no errors or if error is non-actionable */}
-          {(!error || !error.actionable) && (
+          {!error?.actionable && (
             <Alert
               message='OBS v30.2.3 is recommended. Versions below 30.2.3 or 31.0 and above are not supported.'
               type='warning'

--- a/src/components/magicui/magic-card.tsx
+++ b/src/components/magicui/magic-card.tsx
@@ -2,8 +2,8 @@
 
 import clsx from 'clsx'
 import { motion, useMotionTemplate, useMotionValue } from 'framer-motion'
-import { useEffect, useRef } from 'react'
 import type React from 'react'
+import { useEffect, useRef } from 'react'
 
 interface MagicCardProps {
   children: React.ReactNode
@@ -45,10 +45,7 @@ export function MagicCard({
   }, [mouseX, mouseY])
 
   return (
-    <div
-      ref={cardRef}
-      className={clsx('group relative flex size-full overflow-hidden', className)}
-    >
+    <div ref={cardRef} className={clsx('group relative flex size-full overflow-hidden', className)}>
       <div className='relative pointer-events-none z-20 w-full'>{children}</div>
       <motion.div
         className='absolute pointer-events-none -inset-px opacity-0 transition duration-300 group-hover:opacity-100'

--- a/src/lib/hooks/openDotaAPI.tsx
+++ b/src/lib/hooks/openDotaAPI.tsx
@@ -29,7 +29,7 @@ export async function getMatchData(matchId: string, heroId: number) {
     const opendotaMatch = await axios(`https://api.opendota.com/api/matches/${matchId}`)
 
     // If the match data is incomplete, we might need to request parsing
-    if (!opendotaMatch.data || !opendotaMatch.data.players) {
+    if (!opendotaMatch.data?.players) {
       console.log(`[MMR] Match ${matchId} data incomplete, attempting to request parsing`)
       try {
         const jobId = await createJob(matchId)

--- a/src/pages/api/admin/scheduled-messages/[id].ts
+++ b/src/pages/api/admin/scheduled-messages/[id].ts
@@ -5,7 +5,7 @@ import prisma from '@/lib/db'
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   const session = await getServerSession(req, res, authOptions)
-  if (!session || !session.user || !session.user.role?.includes('admin')) {
+  if (!session?.user?.role?.includes('admin')) {
     return res.status(401).json({ error: 'Unauthorized' })
   }
 

--- a/src/pages/api/admin/scheduled-messages/index.ts
+++ b/src/pages/api/admin/scheduled-messages/index.ts
@@ -5,7 +5,7 @@ import prisma from '@/lib/db'
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   const session = await getServerSession(req, res, authOptions)
-  if (!session || !session.user || !session.user.role?.includes('admin')) {
+  if (!session?.user?.role?.includes('admin')) {
     return res.status(401).json({ error: 'Unauthorized' })
   }
 

--- a/src/pages/api/get-moderated-channels.ts
+++ b/src/pages/api/get-moderated-channels.ts
@@ -99,7 +99,7 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
     return res.status(403).json({ message: 'Forbidden' })
   }
 
-  if (search && (!session?.user?.role || !session.user.role?.includes('admin'))) {
+  if (search && !session?.user?.role?.includes('admin')) {
     return res.status(403).json({ message: 'Forbidden' })
   }
 

--- a/src/pages/api/stripe/apply-gift-credit.ts
+++ b/src/pages/api/stripe/apply-gift-credit.ts
@@ -163,7 +163,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         })
 
         // Ensure the subscription was created successfully
-        if (!newStripeSubscription || !newStripeSubscription.id) {
+        if (!newStripeSubscription?.id) {
           throw new Error('Failed to create Stripe subscription object.')
         }
 
@@ -258,7 +258,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         })
 
         // Ensure the subscription was created successfully
-        if (!newStripeSubscription || !newStripeSubscription.id) {
+        if (!newStripeSubscription?.id) {
           throw new Error('Failed to create Stripe subscription object.')
         }
 

--- a/src/pages/api/test-gift-notification.ts
+++ b/src/pages/api/test-gift-notification.ts
@@ -15,7 +15,7 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
     return res.status(401).json({ message: 'Unauthorized' })
   }
 
-  if (!session || !session.user || !session.user.role?.includes('admin')) {
+  if (!session?.user?.role?.includes('admin')) {
     return res.status(401).json({ error: 'Unauthorized' })
   }
 

--- a/src/pages/api/update-emote-set.ts
+++ b/src/pages/api/update-emote-set.ts
@@ -64,7 +64,7 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
     }
 
     // Check if stvResponse is valid
-    if (!stvResponse || !stvResponse.user) {
+    if (!stvResponse?.user) {
       console.error('Failed to get 7TV user:', stvResponse)
       return res.status(404).json({ message: '7TV user not found' })
     }
@@ -78,7 +78,7 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
         name: 'DotabodEmotes',
       })
 
-      if (!result || !result.emoteSetId) {
+      if (!result?.emoteSetId) {
         console.error('Failed to get or create emote set:', result)
         return res.status(500).json({ message: 'Failed to get or create emote set' })
       }

--- a/src/pages/dashboard/admin/index.tsx
+++ b/src/pages/dashboard/admin/index.tsx
@@ -48,7 +48,7 @@ const AdminPage = () => {
   useEffect(() => {
     if (status === 'loading') return
 
-    if (!session?.user?.role || !session.user.role?.includes('admin')) {
+    if (!session?.user?.role?.includes('admin')) {
       router.push('/404')
       return
     }
@@ -381,7 +381,7 @@ const AdminPage = () => {
     },
   ]
 
-  if (!session?.user?.role || !session.user.role?.includes('admin')) {
+  if (!session?.user?.role?.includes('admin')) {
     return null
   }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- replace the custom billing period radio buttons with semantic native radio inputs
- clean up Biome optional-chaining findings across API and admin files
- fix import ordering and formatting drift in the magic card component

## Verification
- `npm ci`
- `npx biome ci .`
- `npm run typecheck`
- `npm run test`
- GitHub Actions `CI` workflow passed on the branch

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d52cf766-d116-449d-b1d6-6d380d9d054f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d52cf766-d116-449d-b1d6-6d380d9d054f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

