### PR TITLE
Skip username prerender during maintenance mode

### DIFF
--- a/src/pages/[username].tsx
+++ b/src/pages/[username].tsx
@@ -473,6 +473,13 @@ interface UserProfileProps {
   username: string
 }
 
+function isMaintenanceModeEnabled() {
+  return (
+    process.env.IS_IN_MAINTENANCE_MODE === 'true' ||
+    process.env.NEXT_PUBLIC_IS_IN_MAINTENANCE_MODE === 'true'
+  )
+}
+
 const CommandsPage = ({ userData, subscriptionInfo, username }: UserProfileProps) => {
   const router = useRouter()
 
@@ -530,6 +537,13 @@ const CommandsPage = ({ userData, subscriptionInfo, username }: UserProfileProps
 }
 
 export const getStaticPaths: GetStaticPaths = async () => {
+  if (isMaintenanceModeEnabled()) {
+    return {
+      paths: [],
+      fallback: 'blocking',
+    }
+  }
+
   // Pre-build only the most popular users for fastest loading
   const topUsers = await prisma.user.findMany({
     where: {
@@ -555,6 +569,15 @@ export const getStaticPaths: GetStaticPaths = async () => {
 
 export const getStaticProps: GetStaticProps<UserProfileProps> = async ({ params }) => {
   const username = params?.username as string
+
+  if (isMaintenanceModeEnabled()) {
+    return {
+      redirect: {
+        destination: '/maintenance',
+        permanent: false,
+      },
+    }
+  }
 
   if (!username) {
     return { notFound: true }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add a maintenance-mode helper for the public username page
- skip `getStaticPaths` database prebuild work when maintenance mode is enabled
- redirect `getStaticProps` for `/[username]` to `/maintenance` before any Prisma calls

## Verification
- ran `npm ci && IS_IN_MAINTENANCE_MODE=true npm run build`
- confirmed the build no longer fails on Prisma/database access for `/[username]`
- local build then proceeded to a separate missing-env failure for `TWITCH_CLIENT_ID` / `TWITCH_CLIENT_SECRET`, showing the original database blocker was removed
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-695587b7-4872-4e2c-9f90-2cffd1c717e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-695587b7-4872-4e2c-9f90-2cffd1c717e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

