### PR TITLE
Redesign gift Pro pages; drop stream overlay promise

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,8 @@ public/install.ps1
 !src/lib/private/install.ps1
 
 **/.claude/settings.local.json
+
+# Local agent skill installs and browser-automation output
+.claude/skills/
+.agents/skills/
+.playwright-mcp/

--- a/src/__tests__/components/Gift/GiftPreview.test.tsx
+++ b/src/__tests__/components/Gift/GiftPreview.test.tsx
@@ -2,20 +2,20 @@ import { render, screen } from '@testing-library/react'
 import { describe, expect, it, vi } from 'vite-plus/test'
 import { GiftPreview } from '@/components/Gift/GiftSubscriptionForm/GiftPreview'
 
-vi.mock('@/components/Overlay/GiftAlert/GiftSubscriptionAlert', () => ({
-  default: ({ senderName }: { senderName: string }) => <div>Alert {senderName}</div>,
-}))
-
 vi.mock('@/components/TwitchChat', () => ({
   default: ({ responses }: { responses: React.ReactNode[] }) => <div>{responses}</div>,
 }))
 
-describe('GiftPreview', () => {
-  it('shows chat and overlay preview', () => {
-    render(<GiftPreview senderName='Tester' giftMessage='hello' quantity={1} />)
+vi.mock('@/ui/card', () => ({
+  Card: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}))
 
-    expect(screen.getByText('Gift Subscription Preview')).toBeInTheDocument()
-    expect(screen.getByText('Alert Tester')).toBeInTheDocument()
+describe('GiftPreview', () => {
+  it('shows the Twitch chat preview with sender and message', () => {
+    render(<GiftPreview senderName='Tester' giftMessage='hello' />)
+
+    expect(screen.getByText('How it lands in their chat')).toBeInTheDocument()
+    expect(screen.getByText('Tester')).toBeInTheDocument()
     expect(screen.getByText('hello')).toBeInTheDocument()
   })
 })

--- a/src/components/Gift/GiftSubscriptionForm/GiftPreview.tsx
+++ b/src/components/Gift/GiftSubscriptionForm/GiftPreview.tsx
@@ -1,16 +1,12 @@
-import { Card, Typography } from 'antd'
-import GiftSubscriptionAlert from '@/components/Overlay/GiftAlert/GiftSubscriptionAlert'
 import TwitchChat from '@/components/TwitchChat'
-
-const { Title, Paragraph, Text } = Typography
+import { Card } from '@/ui/card'
 
 interface GiftPreviewProps {
   senderName: string
   giftMessage: string
-  quantity: number
 }
 
-export const GiftPreview = ({ senderName, giftMessage, quantity }: GiftPreviewProps) => {
+export const GiftPreview = ({ senderName, giftMessage }: GiftPreviewProps) => {
   const giftChatMessage = (
     <>
       {senderName === 'Anonymous' ? (
@@ -22,7 +18,7 @@ export const GiftPreview = ({ senderName, giftMessage, quantity }: GiftPreviewPr
         <span className='space-x-1'>
           <span>
             A gift sub for Dotabod Pro was just gifted by{' '}
-            <span className='text-purple-400 font-semibold'>{senderName}</span>!
+            <span className='font-semibold text-purple-400'>{senderName}</span>!
           </span>
           {giftMessage && <span>{giftMessage}</span>}
         </span>
@@ -31,38 +27,18 @@ export const GiftPreview = ({ senderName, giftMessage, quantity }: GiftPreviewPr
   )
 
   return (
-    <Card className='w-full md:w-auto'>
-      <Title level={4}>Gift Subscription Preview</Title>
-      <Paragraph>
-        Here's how your gift will appear in the streamer's Twitch chat and overlay when they receive
-        it:
-      </Paragraph>
+    <Card className='h-full'>
+      <h2 className='text-lg font-medium text-gray-100'>How it lands in their chat</h2>
+      <p className='mt-1 text-sm text-gray-400'>
+        This updates live as you fill out the form. Here's the message your gift posts in the
+        streamer's Twitch chat.
+      </p>
 
-      <div className='space-y-6'>
-        <div>
-          <Text strong className='mb-2 block'>
-            Twitch Chat
-          </Text>
-          <TwitchChat responses={[giftChatMessage]} />
-        </div>
-
-        <div>
-          <Text strong className='mb-2 block'>
-            Stream Overlay
-          </Text>
-          <div className='rounded-md bg-gray-800 p-2 sm:p-4'>
-            <div className='relative h-40 sm:h-52 w-full overflow-hidden flex items-center justify-center'>
-              <GiftSubscriptionAlert
-                senderName={senderName}
-                giftType='monthly'
-                giftQuantity={quantity}
-                giftMessage={giftMessage}
-                preview={true}
-                className=''
-              />
-            </div>
-          </div>
-        </div>
+      <div className='mt-5'>
+        <span className='mb-2 block text-xs font-medium uppercase tracking-[0.2em] text-gray-500'>
+          Twitch chat
+        </span>
+        <TwitchChat responses={[giftChatMessage]} />
       </div>
     </Card>
   )

--- a/src/components/Gift/GiftSubscriptionForm/GiftSubscriptionForm.tsx
+++ b/src/components/Gift/GiftSubscriptionForm/GiftSubscriptionForm.tsx
@@ -1,21 +1,27 @@
-import { Alert, App, Button, Form, Input, InputNumber, Space, Tooltip, Typography } from 'antd'
+import { Alert, App, Button, Form, Input, InputNumber } from 'antd'
+import clsx from 'clsx'
 import { detect } from 'curse-filter'
+import { motion, useReducedMotion } from 'framer-motion'
+import {
+  GiftIcon,
+  InfinityIcon,
+  ReceiptTextIcon,
+  ShieldCheckIcon,
+  SparklesIcon,
+} from 'lucide-react'
 import Link from 'next/link'
 import { useEffect, useState } from 'react'
 import { plans } from '@/components/Billing/BillingPlans'
 import { createGiftCheckoutSession } from '@/lib/gift-subscription'
 import { Card } from '@/ui/card'
-import { type PricePeriod, SUBSCRIPTION_TIERS } from '@/utils/subscription'
+import { SUBSCRIPTION_TIERS } from '@/utils/subscription'
 import { GiftPreview } from './GiftPreview'
-
-const { Title, Text, Paragraph } = Typography
 
 // Define the form values type
 interface GiftFormValues {
   recipientUsername: string
   giftSenderName?: string
   giftMessage?: string
-  quantity?: number
 }
 
 interface GiftSubscriptionFormProps {
@@ -24,6 +30,32 @@ interface GiftSubscriptionFormProps {
   canceled?: boolean
   loading?: boolean
 }
+
+const DURATION_PRESETS = [1, 3, 6, 12]
+
+const PRO_HIGHLIGHTS = [
+  'Auto Twitch predictions on every match',
+  'Advanced overlays: XL minimap, anti-snipe blockers',
+  'Notable players overlay with country flags',
+  'Auto Roshan and Aegis timers',
+  'OBS scene switcher and Spotify integration',
+  'Pro chat commands (!hero, !np, !items, !smurfs)',
+]
+
+const HOW_IT_WORKS = [
+  {
+    title: 'They get notified in chat',
+    body: 'A message in their Twitch chat announces your gift, usually within 1 to 3 minutes of checkout.',
+  },
+  {
+    title: 'New to Pro? Credits apply automatically',
+    body: "If they've never subscribed, they set up Pro and your credits cover the months you gifted. No charge until those run out.",
+  },
+  {
+    title: 'Already Pro? The time just stacks',
+    body: 'Existing subscribers keep their plan and your credits extend it, so they get Pro for longer.',
+  },
+]
 
 export const GiftSubscriptionForm = ({
   recipientUsername,
@@ -38,10 +70,20 @@ export const GiftSubscriptionForm = ({
   const [usernameError, setUsernameError] = useState<string | null>(null)
   const [senderName, setSenderName] = useState<string>('Anonymous')
   const [giftMessage, setGiftMessage] = useState<string>('')
-  const selectedTier = SUBSCRIPTION_TIERS.PRO
 
-  // Always use monthly for gift subscriptions
-  const activePeriod: PricePeriod = 'monthly'
+  const reduceMotion = useReducedMotion()
+  const fadeUp = (delay: number) => ({
+    initial: reduceMotion ? false : { opacity: 0, y: 14 },
+    animate: { opacity: 1, y: 0 },
+    transition: { delay, duration: 0.5, ease: [0.22, 1, 0.36, 1] as const },
+  })
+
+  // Pull the live monthly Pro price so the buyer always sees the total.
+  const proMonthly = plans.find((p) => p.tier === SUBSCRIPTION_TIERS.PRO)?.price.monthly ?? '$6'
+  const currency = proMonthly.match(/[^0-9.]/)?.[0] ?? '$'
+  const unitPrice = Number.parseFloat(proMonthly.replaceAll(/[^0-9.]/g, '')) || 6
+  const total = unitPrice * quantity
+  const formatPrice = (value: number) => `${currency}${value % 1 === 0 ? value : value.toFixed(2)}`
 
   // Function to check for profanity in text
   const checkForProfanity = (text: string | undefined): boolean => {
@@ -82,10 +124,9 @@ export const GiftSubscriptionForm = ({
       setFormError(null)
       setUsernameError(null)
 
-      // Ensure quantity is a number
       const submittedValues = {
         ...values,
-        quantity: Number(values.quantity) || 1,
+        quantity: Number(quantity) || 1,
       }
 
       // Client-side profanity check for immediate feedback
@@ -175,259 +216,276 @@ export const GiftSubscriptionForm = ({
     }
   }
 
-  // Calculate the total price based on quantity and period
-  const _calculateTotalPrice = () => {
-    const basePrice = plans.find((p) => p.tier === selectedTier)?.price[activePeriod] || '$0'
-
-    // Extract the numeric value from the price string (e.g., "$5" -> 5)
-    const numericPrice = Number.parseFloat(basePrice.replaceAll(/[^0-9.]/g, ''))
-    const total = numericPrice * quantity
-
-    // Format the total price with the same currency symbol
-    const currencySymbol = basePrice.match(/[^0-9.]/g)?.[0] || '$'
-    return `${currencySymbol}${total.toFixed(2)}`
-  }
-
   const displayName = recipientDisplayName || recipientUsername || 'this streamer'
+  const recipientLink = recipientUsername ? (
+    <Link
+      href={`/${recipientUsername}`}
+      className='text-purple-300 underline-offset-4 hover:underline'
+    >
+      {displayName}
+    </Link>
+  ) : null
 
   return (
-    <div className='mx-auto pb-12 flex flex-wrap flex-col gap-4'>
-      <div className='flex flex-row justify-center gap-4 px-4 md:px-0'>
-        {canceled && (
-          <Alert
-            message='Payment Canceled'
-            description="Your gift subscription payment was canceled. You can try again when you're ready."
-            type='info'
-            showIcon
-            className='mb-8 w-full'
-          />
-        )}
-      </div>
+    <div className='mx-auto w-full max-w-5xl px-4 pb-20 md:px-6'>
+      {canceled && (
+        <Alert
+          message='Payment canceled'
+          description="Your gift checkout was canceled. Nothing was charged. Pick up where you left off whenever you're ready."
+          type='info'
+          showIcon
+          className='mt-8'
+        />
+      )}
 
-      <div className='flex flex-col md:flex-row flex-wrap justify-center gap-4 px-4 md:px-0'>
-        <Card className='w-full md:w-auto'>
-          <Title level={4}>
-            {recipientUsername ? (
-              <>
-                Gift a Subscription to <Link href={`/${recipientUsername}`}>{displayName}</Link>
-              </>
-            ) : (
-              'Gift a Subscription'
-            )}
-          </Title>
-          <Paragraph>
-            {recipientUsername ? (
-              <>
-                Support <Link href={`/${recipientUsername}`}>{displayName}</Link> by gifting them
-                Dotabod Pro! They'll get access to all Pro features.
-              </>
-            ) : (
-              "Support this streamer by gifting them Dotabod Pro! They'll get access to all Pro features."
-            )}
-          </Paragraph>
+      {/* Hero */}
+      <motion.header {...fadeUp(0)} className='pt-12 md:pt-16'>
+        <p className='text-xs font-medium uppercase tracking-[0.2em] text-gray-500'>
+          A gift that keeps streaming
+        </p>
+        <h1 className='mt-3 text-balance text-4xl font-semibold leading-tight tracking-tight text-gray-100 sm:text-5xl'>
+          {recipientLink ? <>Gift Dotabod Pro to {recipientLink}</> : 'Gift Dotabod Pro'}
+        </h1>
+        <p className='mt-4 max-w-2xl text-pretty text-lg text-gray-400'>
+          {recipientUsername
+            ? `Hand ${displayName} the full Dotabod kit: auto predictions, advanced overlays, and every pro command. You pay once, they get the months.`
+            : 'Hand your favorite Dota 2 streamer the full Dotabod kit: auto predictions, advanced overlays, and every pro command. You pay once, they get the months.'}
+        </p>
+        <ul className='mt-6 flex flex-wrap items-center gap-x-3 gap-y-2 text-sm text-gray-500'>
+          <li className='flex items-center gap-1.5'>
+            <ReceiptTextIcon className='h-4 w-4 text-gray-500' aria-hidden />
+            {formatPrice(unitPrice)} per month
+          </li>
+          <li aria-hidden className='text-gray-700'>
+            ·
+          </li>
+          <li className='flex items-center gap-1.5'>
+            <InfinityIcon className='h-4 w-4 text-gray-500' aria-hidden />
+            Pay once, no recurring charges
+          </li>
+          <li aria-hidden className='text-gray-700'>
+            ·
+          </li>
+          <li className='flex items-center gap-1.5'>
+            <ShieldCheckIcon className='h-4 w-4 text-gray-500' aria-hidden />
+            Secure checkout via Stripe
+          </li>
+        </ul>
+      </motion.header>
 
-          <Form
-            form={form}
-            layout='vertical'
-            onFinish={handleSubmit}
-            requiredMark={false}
-            initialValues={{
-              quantity: 1,
-              recipientUsername: recipientUsername || '',
-            }}
-          >
-            <Form.Item
-              name='quantity'
-              label='Duration'
-              tooltip='How many months of Pro the recipient will receive'
+      {/* Form + live preview */}
+      <div className='mt-10 grid grid-cols-1 gap-6 lg:grid-cols-[minmax(0,1fr)_minmax(0,1fr)] lg:gap-8'>
+        <motion.div {...fadeUp(0.08)}>
+          <Card className='h-full'>
+            <Form
+              form={form}
+              layout='vertical'
+              onFinish={handleSubmit}
+              requiredMark={false}
+              initialValues={{ recipientUsername: recipientUsername || '' }}
             >
-              <div className='flex items-center'>
-                <InputNumber
-                  min={1}
-                  max={100}
-                  value={quantity}
-                  onChange={(value) => {
-                    const newQuantity = Number(value) || 1
-                    setQuantity(newQuantity)
-                    form.setFieldsValue({ quantity: newQuantity })
-                  }}
-                  style={{ width: 100 }}
-                  className='w-24 sm:w-32'
-                />
-                <Text className='ml-2'>months</Text>
-              </div>
-            </Form.Item>
-
-            <Form.Item
-              name='recipientUsername'
-              label="Recipient's Username"
-              rules={[{ message: "Please enter the recipient's username", required: true }]}
-              tooltip='Enter the Twitch username of the streamer you want to gift to'
-              validateStatus={usernameError ? 'error' : undefined}
-              help={usernameError}
-            >
-              <Input
-                placeholder='Enter Twitch username'
-                disabled={Boolean(recipientUsername)}
-                onChange={handleUsernameChange}
-                className='w-full'
-              />
-            </Form.Item>
-
-            <Form.Item
-              name='giftSenderName'
-              label='Your Name (Optional)'
-              tooltip='This will be shown to the recipient'
-              rules={[
-                {
-                  validator: (_, value) => {
-                    // Client-side validation for immediate user feedback
-                    // Server will also validate to ensure security
-                    if (value && checkForProfanity(value)) {
-                      return Promise.reject('Please remove inappropriate language from your name')
-                    }
-                    return Promise.resolve()
-                  },
-                },
-              ]}
-            >
-              <Input
-                placeholder='Your name or leave blank to gift anonymously'
-                onChange={handleSenderNameChange}
-                className='w-full'
-              />
-            </Form.Item>
-
-            <Form.Item
-              name='giftMessage'
-              label='Gift Message (Optional)'
-              tooltip='A personal message to include with your gift'
-              rules={[
-                {
-                  validator: (_, value) => {
-                    // Client-side validation for immediate user feedback
-                    // Server will also validate to ensure security
-                    if (value && checkForProfanity(value)) {
-                      return Promise.reject(
-                        'Please remove inappropriate language from your message',
-                      )
-                    }
-                    return Promise.resolve()
-                  },
-                },
-              ]}
-            >
-              <Input.TextArea
-                placeholder='Add a personal message'
-                rows={3}
-                maxLength={200}
-                showCount
-                onChange={handleGiftMessageChange}
-                className='w-full'
-              />
-            </Form.Item>
-
-            {formError && (
-              <Form.Item>
-                <div className='ant-form-item-explain ant-form-item-explain-error'>
-                  <div role='alert' className='ant-form-item-explain-error'>
-                    {formError}
+              {/* Duration */}
+              <div className='mb-6'>
+                <span className='block text-sm font-medium text-gray-200'>How long?</span>
+                <p className='mt-0.5 text-xs text-gray-500'>
+                  Each month is one month of Dotabod Pro for the recipient.
+                </p>
+                <div className='mt-3 flex flex-wrap gap-2'>
+                  {DURATION_PRESETS.map((months) => {
+                    const selected = quantity === months
+                    return (
+                      <button
+                        key={months}
+                        type='button'
+                        aria-pressed={selected}
+                        onClick={() => setQuantity(months)}
+                        className={clsx(
+                          'rounded-md border px-4 py-2 text-sm font-medium transition-colors duration-200',
+                          selected
+                            ? 'border-purple-500 bg-purple-500/15 text-purple-200'
+                            : 'border-gray-700 bg-gray-800 text-gray-300 hover:border-gray-600 hover:text-gray-100',
+                        )}
+                      >
+                        {months} {months === 1 ? 'month' : 'months'}
+                      </button>
+                    )
+                  })}
+                  <div className='flex items-center gap-2 rounded-md border border-gray-700 bg-gray-800 px-3 py-1.5'>
+                    <span className='text-xs text-gray-500'>Custom</span>
+                    <InputNumber
+                      min={1}
+                      max={100}
+                      value={quantity}
+                      onChange={(value) => setQuantity(Number(value) || 1)}
+                      controls={false}
+                      size='small'
+                      style={{ width: 56 }}
+                      aria-label='Custom number of months'
+                    />
                   </div>
                 </div>
+              </div>
+
+              <Form.Item
+                name='recipientUsername'
+                label="Recipient's Twitch username"
+                rules={[{ message: "Please enter the recipient's username", required: true }]}
+                validateStatus={usernameError ? 'error' : undefined}
+                help={usernameError}
+              >
+                <Input
+                  placeholder='Enter Twitch username'
+                  disabled={Boolean(recipientUsername)}
+                  onChange={handleUsernameChange}
+                  className='w-full'
+                />
               </Form.Item>
-            )}
 
-            <Form.Item>
-              {usernameError ? (
-                <Tooltip title='Please change the recipient username to continue'>
-                  <Button
-                    type='primary'
-                    htmlType='submit'
-                    loading={isSubmitting}
-                    size='large'
-                    block
-                    disabled={true}
-                    className='mt-2'
-                  >
-                    Continue to Payment
-                  </Button>
-                </Tooltip>
-              ) : (
-                <Button
-                  type='primary'
-                  htmlType='submit'
-                  loading={isSubmitting}
-                  size='large'
-                  block
-                  disabled={isSubmitting}
-                  className='mt-2'
-                >
-                  Continue to Payment
-                </Button>
+              <Form.Item
+                name='giftSenderName'
+                label='Your name (optional)'
+                tooltip='Shown to the recipient. Leave blank to gift anonymously.'
+                rules={[
+                  {
+                    validator: (_, value) => {
+                      if (value && checkForProfanity(value)) {
+                        return Promise.reject('Please remove inappropriate language from your name')
+                      }
+                      return Promise.resolve()
+                    },
+                  },
+                ]}
+              >
+                <Input
+                  placeholder='Your name, or leave blank to gift anonymously'
+                  onChange={handleSenderNameChange}
+                  className='w-full'
+                />
+              </Form.Item>
+
+              <Form.Item
+                name='giftMessage'
+                label='Gift message (optional)'
+                tooltip='A personal note shown with your gift.'
+                rules={[
+                  {
+                    validator: (_, value) => {
+                      if (value && checkForProfanity(value)) {
+                        return Promise.reject(
+                          'Please remove inappropriate language from your message',
+                        )
+                      }
+                      return Promise.resolve()
+                    },
+                  },
+                ]}
+              >
+                <Input.TextArea
+                  placeholder='Add a personal message'
+                  rows={3}
+                  maxLength={200}
+                  showCount
+                  onChange={handleGiftMessageChange}
+                  className='w-full'
+                />
+              </Form.Item>
+
+              {formError && (
+                <div role='alert' className='mb-4 text-sm text-red-300'>
+                  {formError}
+                </div>
               )}
-            </Form.Item>
-          </Form>
-        </Card>
-        <GiftPreview senderName={senderName} giftMessage={giftMessage} quantity={quantity} />
-      </div>
 
-      <div className='max-w-5xl w-full flex flex-col justify-center gap-4 self-center px-4 md:px-0'>
-        <Card>
-          <Title level={4}>Why Gift Dotabod Pro?</Title>
-          <Space direction='vertical' size='middle' className='w-full'>
-            <div className='space-y-1'>
-              <Text strong>Support {recipientUsername ? displayName : 'Streamers'}</Text>
-              <Paragraph className='text-sm sm:text-base'>
-                Help them elevate their stream with professional Dota 2 overlays and analytics.
-              </Paragraph>
-            </div>
-            <div className='space-y-1'>
-              <Text strong>No Recurring Charges</Text>
-              <Paragraph className='text-sm sm:text-base'>
-                You pay once for the duration you choose. No recurring charges for you or the
-                recipient.
-              </Paragraph>
-            </div>
-            <div className='space-y-1'>
-              <Text strong>Subscription Extension</Text>
-              <Paragraph className='text-sm sm:text-base'>
-                Multiple gifts extend the recipient's Pro subscription duration. They'll enjoy Pro
-                features longer.
-              </Paragraph>
-            </div>
-          </Space>
-        </Card>
+              {/* Price summary */}
+              <div className='rounded-lg border border-gray-700 bg-gray-800/60 p-4'>
+                <div className='flex items-center justify-between text-sm text-gray-300'>
+                  <span>
+                    {quantity} {quantity === 1 ? 'month' : 'months'} of Pro
+                  </span>
+                  <span className='text-gray-400'>
+                    {formatPrice(unitPrice)} × {quantity}
+                  </span>
+                </div>
+                <div className='mt-3 flex items-center justify-between border-t border-gray-700 pt-3'>
+                  <span className='text-sm font-medium text-gray-200'>Total, billed once</span>
+                  <span className='text-xl font-semibold text-gray-100'>{formatPrice(total)}</span>
+                </div>
+              </div>
 
-        <Card className='mt-4'>
-          <Title level={4}>How Gift Subscriptions Work</Title>
-          <div className='space-y-3'>
-            <div className='space-y-1'>
-              <Text strong>For New Users:</Text>
-              <Paragraph className='text-sm sm:text-base'>
-                If the recipient has never subscribed to Dotabod Pro, they will need to set up a
-                subscription after receiving your gift. The credits will be automatically applied,
-                so they won't be charged for the duration of your gift.
-              </Paragraph>
-            </div>
+              <Button
+                type='primary'
+                htmlType='submit'
+                loading={isSubmitting}
+                size='large'
+                block
+                disabled={isSubmitting || Boolean(usernameError)}
+                className='mt-4'
+                icon={<GiftIcon className='h-4 w-4' />}
+              >
+                Continue to payment · {formatPrice(total)}
+              </Button>
+              {usernameError && (
+                <p className='mt-2 text-center text-xs text-gray-500'>
+                  Update the recipient username above to continue.
+                </p>
+              )}
+            </Form>
+          </Card>
+        </motion.div>
 
-            <div className='space-y-1'>
-              <Text strong>For Existing Subscribers:</Text>
-              <Paragraph className='text-sm sm:text-base'>
-                If the recipient is already a Pro subscriber, the gift credits will automatically be
-                applied to their account and used when their subscription renews.
-              </Paragraph>
-            </div>
-
-            <div className='space-y-1'>
-              <Text strong>Not Valid for Lifetime Purchases:</Text>
-              <Paragraph className='text-sm sm:text-base'>
-                Gift credits can only be applied toward monthly Pro subscriptions, not toward
-                lifetime purchases.
-              </Paragraph>
-            </div>
+        <motion.div {...fadeUp(0.16)}>
+          <div className='lg:sticky lg:top-24'>
+            <GiftPreview senderName={senderName} giftMessage={giftMessage} />
           </div>
-        </Card>
+        </motion.div>
       </div>
+
+      {/* What you're unlocking + how it works */}
+      <motion.div {...fadeUp(0.24)} className='mt-6 grid grid-cols-1 gap-6 lg:grid-cols-2 lg:gap-8'>
+        <Card className='h-full'>
+          <div className='flex items-center gap-2'>
+            <SparklesIcon className='h-5 w-5 text-purple-300' aria-hidden />
+            <h2 className='text-lg font-medium text-gray-100'>What you're unlocking</h2>
+          </div>
+          <p className='mt-1 text-sm text-gray-400'>
+            Everything in Free, plus the tools streamers actually feel on air.
+          </p>
+          <ul className='mt-4 space-y-2.5'>
+            {PRO_HIGHLIGHTS.map((feature) => (
+              <li key={feature} className='flex items-start gap-2.5 text-sm text-gray-300'>
+                <span
+                  aria-hidden
+                  className='mt-1.5 h-1.5 w-1.5 shrink-0 rounded-full bg-purple-400'
+                />
+                {feature}
+              </li>
+            ))}
+          </ul>
+          <p className='mt-4 text-xs text-gray-500'>
+            Gift credits apply to monthly Pro, not to lifetime purchases.
+          </p>
+        </Card>
+
+        <Card className='h-full'>
+          <div className='flex items-center gap-2'>
+            <GiftIcon className='h-5 w-5 text-purple-300' aria-hidden />
+            <h2 className='text-lg font-medium text-gray-100'>How it works</h2>
+          </div>
+          <ol className='mt-4 space-y-4'>
+            {HOW_IT_WORKS.map((step, index) => (
+              <li key={step.title} className='flex items-start gap-3'>
+                <span className='mt-0.5 flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-purple-500/15 text-xs font-semibold text-purple-200'>
+                  {index + 1}
+                </span>
+                <div>
+                  <p className='text-sm font-medium text-gray-200'>{step.title}</p>
+                  <p className='mt-0.5 text-sm text-gray-400'>{step.body}</p>
+                </div>
+              </li>
+            ))}
+          </ol>
+        </Card>
+      </motion.div>
     </div>
   )
 }

--- a/src/pages/gift-success.tsx
+++ b/src/pages/gift-success.tsx
@@ -1,59 +1,58 @@
 import confetti from 'canvas-confetti'
-import { ArrowRightIcon, CakeIcon, ClockIcon, GiftIcon } from 'lucide-react'
+import { motion, useReducedMotion } from 'framer-motion'
+import { ArrowRightIcon, CheckIcon, ClockIcon, GiftIcon } from 'lucide-react'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
 import type { ReactElement } from 'react'
 import { useEffect, useState } from 'react'
 import HomepageShell from '@/components/Homepage/HomepageShell'
-import GiftSubscriptionAlert from '@/components/Overlay/GiftAlert/GiftSubscriptionAlert'
 import TwitchChat from '@/components/TwitchChat'
 import type { NextPageWithLayout } from '@/pages/_app'
 import { Card } from '@/ui/card'
 
+const NEXT_STEPS = [
+  'The recipient gets a notification in their Twitch chat.',
+  "New to Pro? They set up a subscription and your credits cover the gifted months, so they aren't charged until those run out.",
+  'Already a Pro subscriber? Your credits stack onto their account and extend how long they keep Pro.',
+]
+
 const GiftSuccessPage: NextPageWithLayout = () => {
   const router = useRouter()
   const { recipient, senderName, quantity, giftMessage } = router.query
-  const [showConfetti, setShowConfetti] = useState(false)
+  const [hasCelebrated, setHasCelebrated] = useState(false)
+  const reduceMotion = useReducedMotion()
 
   // Parse quantity to a number (default to 1 if undefined or invalid)
   const parsedQuantity = Number.parseInt(quantity as string, 10) || 1
   const formattedSenderName = (senderName as string) || 'Anonymous'
   const formattedGiftMessage = (giftMessage as string) || ''
 
-  // Trigger confetti effect when the page loads
+  const fadeUp = (delay: number) => ({
+    initial: reduceMotion ? false : { opacity: 0, y: 14 },
+    animate: { opacity: 1, y: 0 },
+    transition: { delay, duration: 0.5, ease: [0.22, 1, 0.36, 1] as const },
+  })
+
+  // Trigger confetti when the page loads, unless the user prefers reduced motion.
   useEffect(() => {
-    if (typeof window !== 'undefined' && !showConfetti) {
-      setShowConfetti(true)
-
-      // Create a confetti effect
-      const duration = 3 * 1000
-      const end = Date.now() + duration
-
-      const frame = () => {
-        void confetti({
-          angle: 60,
-          colors: ['#5D5FEF', '#3F83F8', '#10B981'],
-          origin: { x: 0 },
-          particleCount: 2,
-          spread: 55,
-        })
-
-        void confetti({
-          angle: 120,
-          colors: ['#5D5FEF', '#3F83F8', '#10B981'],
-          origin: { x: 1 },
-          particleCount: 2,
-          spread: 55,
-        })
-
-        if (Date.now() < end) {
-          requestAnimationFrame(frame)
-        }
-      }
-
-      frame()
+    if (typeof window === 'undefined' || reduceMotion || hasCelebrated) {
+      return
     }
-  }, [showConfetti])
+    setHasCelebrated(true)
+
+    const duration = 3 * 1000
+    const end = Date.now() + duration
+    const colors = ['#a855f7', '#c084fc', '#7c3aed']
+
+    const frame = () => {
+      void confetti({ angle: 60, colors, origin: { x: 0 }, particleCount: 2, spread: 55 })
+      void confetti({ angle: 120, colors, origin: { x: 1 }, particleCount: 2, spread: 55 })
+      if (Date.now() < end) {
+        requestAnimationFrame(frame)
+      }
+    }
+    frame()
+  }, [hasCelebrated, reduceMotion])
 
   // Create gift message preview for Twitch chat
   const giftChatMessage = (
@@ -63,172 +62,128 @@ const GiftSuccessPage: NextPageWithLayout = () => {
       ) : (
         <span>
           A gift sub for Dotabod Pro was just gifted by{' '}
-          <span className='text-purple-400 font-semibold'>{formattedSenderName}</span>!
+          <span className='font-semibold text-purple-400'>{formattedSenderName}</span>!
         </span>
       )}
     </>
   )
 
   return (
-    <div className='container mx-auto flex max-w-3xl flex-col items-center py-16 text-center'>
-      <div className='mb-6 flex h-20 w-20 items-center justify-center rounded-full bg-purple-100'>
-        <GiftIcon className='h-10 w-10 text-purple-600' />
-      </div>
+    <div className='mx-auto w-full max-w-3xl px-4 pb-20 md:px-6'>
+      <motion.header {...fadeUp(0)} className='pt-16 text-center'>
+        <div className='mx-auto flex h-16 w-16 items-center justify-center rounded-full bg-purple-500/15 ring-1 ring-purple-500/30'>
+          <CheckIcon className='h-8 w-8 text-purple-300' aria-hidden />
+        </div>
+        <h1 className='mt-6 text-balance text-4xl font-semibold tracking-tight text-gray-100 sm:text-5xl'>
+          Your gift is on its way
+        </h1>
+        <p className='mx-auto mt-4 max-w-lg text-pretty text-lg text-gray-400'>
+          {recipient ? (
+            <>
+              You gifted <span className='font-medium text-gray-200'>{parsedQuantity}</span>{' '}
+              {parsedQuantity === 1 ? 'month' : 'months'} of Dotabod Pro to{' '}
+              <span className='font-medium text-gray-200'>{recipient}</span>. They'll be notified
+              shortly.
+            </>
+          ) : (
+            <>
+              You gifted {parsedQuantity} {parsedQuantity === 1 ? 'month' : 'months'} of Dotabod
+              Pro. The recipient will be notified shortly.
+            </>
+          )}
+        </p>
+      </motion.header>
 
-      <h1 className='mb-3 text-3xl font-bold'>Gift Sent Successfully!</h1>
-
-      <p className='mb-8 max-w-lg text-muted-foreground'>
-        {recipient ? (
-          <>
-            Your gift subscription to{' '}
-            <span className='font-medium text-foreground'>{recipient}</span> has been sent
-            successfully. They'll be notified about your generous gift!
-          </>
-        ) : (
-          <>
-            Your gift subscription has been sent successfully. The recipient will be notified about
-            your generous gift!
-          </>
-        )}
-      </p>
-
-      <div className='grid grid-cols-1 md:grid-cols-2 gap-6 w-full mb-8'>
-        <Card className='p-6'>
-          <div className='flex items-center gap-3 mb-4'>
-            <GiftIcon className='h-5 w-5 text-primary' />
-            <h2 className='text-lg font-medium'>Gift Details</h2>
+      <motion.div {...fadeUp(0.08)} className='mt-10 grid grid-cols-1 gap-6 md:grid-cols-2'>
+        <Card>
+          <div className='flex items-center gap-2'>
+            <GiftIcon className='h-5 w-5 text-purple-300' aria-hidden />
+            <h2 className='text-lg font-medium text-gray-100'>Gift details</h2>
           </div>
-
-          <div className='space-y-4 text-left'>
-            <div className='flex items-start gap-2'>
-              <span className='font-medium min-w-28'>Recipient:</span>
-              <span>{recipient || 'Not specified'}</span>
+          <dl className='mt-4 space-y-3 text-sm'>
+            <div className='flex justify-between gap-3'>
+              <dt className='text-gray-500'>Recipient</dt>
+              <dd className='text-gray-200'>{recipient || 'Not specified'}</dd>
             </div>
-
-            <div className='flex items-start gap-2'>
-              <span className='font-medium min-w-28'>From:</span>
-              <span>{formattedSenderName}</span>
+            <div className='flex justify-between gap-3'>
+              <dt className='text-gray-500'>From</dt>
+              <dd className='text-gray-200'>{formattedSenderName}</dd>
             </div>
-
-            <div className='flex items-start gap-2'>
-              <span className='font-medium min-w-28'>Duration:</span>
-              <span>
-                {parsedQuantity} {parsedQuantity === 1 ? 'month' : 'months'} of Dotabod Pro
-              </span>
+            <div className='flex justify-between gap-3'>
+              <dt className='text-gray-500'>Duration</dt>
+              <dd className='text-gray-200'>
+                {parsedQuantity} {parsedQuantity === 1 ? 'month' : 'months'} of Pro
+              </dd>
             </div>
-
             {formattedGiftMessage && (
-              <div className='flex items-start gap-2'>
-                <span className='font-medium min-w-28'>Message:</span>
-                <span className='italic'>"{formattedGiftMessage}"</span>
+              <div className='flex justify-between gap-3'>
+                <dt className='text-gray-500'>Message</dt>
+                <dd className='text-right italic text-gray-300'>"{formattedGiftMessage}"</dd>
               </div>
             )}
-          </div>
+          </dl>
         </Card>
 
-        <Card className='p-6'>
-          <div className='flex items-center gap-3 mb-4'>
-            <ClockIcon className='h-5 w-5 text-amber-500' />
-            <h2 className='text-lg font-medium'>Important Note</h2>
+        <Card>
+          <div className='flex items-center gap-2'>
+            <ClockIcon className='h-5 w-5 text-amber-300' aria-hidden />
+            <h2 className='text-lg font-medium text-gray-100'>Good to know</h2>
           </div>
-
-          <div className='space-y-4 text-left'>
+          <div className='mt-4 space-y-3 text-sm text-gray-400'>
             <p>
-              The gift notification may take <span className='font-medium'>1-3 minutes</span> to
-              appear on the recipient's stream overlay and in their Twitch chat.
+              The notification can take{' '}
+              <span className='font-medium text-gray-200'>1 to 3 minutes</span> to reach the
+              recipient's Twitch chat.
             </p>
-            <p>If the recipient is streaming right now, they'll see your gift shortly!</p>
+            <p>If they're live right now, your gift will show up on stream shortly.</p>
           </div>
         </Card>
-      </div>
+      </motion.div>
 
-      <div className='mb-8 w-full'>
-        <Card className='p-6'>
-          <div className='flex items-center gap-3 mb-4'>
-            <CakeIcon className='h-5 w-5 text-purple-500' />
-            <h2 className='text-lg font-medium'>Gift Preview</h2>
-          </div>
-
-          <div className='grid grid-cols-1 md:grid-cols-2 gap-6'>
-            <div>
-              <h3 className='text-left text-base font-medium mb-2'>Twitch Chat</h3>
-              <TwitchChat responses={[giftChatMessage]} />
-            </div>
-
-            <div>
-              <h3 className='text-left text-base font-medium mb-2'>Stream Overlay</h3>
-              <div className='rounded-md bg-gray-800 p-4 flex items-center justify-center'>
-                <div className='relative h-48 overflow-hidden flex items-center justify-center'>
-                  <GiftSubscriptionAlert
-                    senderName={formattedSenderName}
-                    giftType='monthly'
-                    giftQuantity={parsedQuantity}
-                    giftMessage={formattedGiftMessage}
-                    preview={true}
-                    className='scale-75'
-                  />
-                </div>
-              </div>
-            </div>
+      <motion.div {...fadeUp(0.16)} className='mt-6'>
+        <Card>
+          <h2 className='text-lg font-medium text-gray-100'>How it'll appear</h2>
+          <div className='mt-4'>
+            <span className='mb-2 block text-xs font-medium uppercase tracking-[0.2em] text-gray-500'>
+              Twitch chat
+            </span>
+            <TwitchChat responses={[giftChatMessage]} />
           </div>
         </Card>
-      </div>
+      </motion.div>
 
-      <Card className='mb-8'>
-        <div className='flex items-center gap-3'>
-          <GiftIcon className='h-5 w-5 text-primary' />
-          <h2 className='text-lg font-medium'>What happens next?</h2>
-        </div>
+      <motion.div {...fadeUp(0.24)} className='mt-6'>
+        <Card>
+          <h2 className='text-lg font-medium text-gray-100'>What happens next</h2>
+          <ol className='mt-4 space-y-3'>
+            {NEXT_STEPS.map((step, index) => (
+              <li key={step} className='flex items-start gap-3 text-sm text-gray-300'>
+                <span className='mt-0.5 flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-purple-500/15 text-xs font-semibold text-purple-200'>
+                  {index + 1}
+                </span>
+                <span className='text-gray-400'>{step}</span>
+              </li>
+            ))}
+          </ol>
+        </Card>
+      </motion.div>
 
-        <ul className='mt-4 space-y-3 text-left'>
-          <li className='flex items-start gap-3'>
-            <div className='mt-0.5 flex h-5 w-5 items-center justify-center rounded-full bg-primary/10 text-xs font-bold text-primary'>
-              1
-            </div>
-            <span>
-              The recipient will receive a notification about your gift in their Twitch chat and
-              stream overlay.
-            </span>
-          </li>
-          <li className='flex items-start gap-3'>
-            <div className='mt-0.5 flex h-5 w-5 items-center justify-center rounded-full bg-primary/10 text-xs font-bold text-primary'>
-              2
-            </div>
-            <span>
-              If the recipient has never subscribed to Dotabod Pro, they will need to set up a
-              subscription after receiving your gift. The credits will be automatically applied, so
-              they won't be charged for the duration of your gift.
-            </span>
-          </li>
-          <li className='flex items-start gap-3'>
-            <div className='mt-0.5 flex h-5 w-5 items-center justify-center rounded-full bg-primary/10 text-xs font-bold text-primary'>
-              3
-            </div>
-            <span>
-              If the recipient is already a Pro subscriber, the gift credits will automatically be
-              applied to their account and used when their subscription renews.
-            </span>
-          </li>
-        </ul>
-      </Card>
-
-      <div className='flex flex-col gap-4 sm:flex-row'>
+      <motion.div {...fadeUp(0.32)} className='mt-8 flex flex-col justify-center gap-3 sm:flex-row'>
         <Link
           href='/gift'
-          className='inline-flex items-center justify-center gap-2 rounded-md border bg-card px-4 py-2 text-sm font-medium shadow-sm hover:bg-accent'
+          className='inline-flex items-center justify-center gap-2 rounded-md border border-gray-700 bg-gray-800 px-4 py-2 text-sm font-medium text-gray-200 transition-colors duration-200 hover:border-gray-600 hover:text-purple-300'
         >
-          <GiftIcon className='h-4 w-4' />
-          Send Another Gift
+          <GiftIcon className='h-4 w-4' aria-hidden />
+          Send another gift
         </Link>
-
         <Link
           href='/'
-          className='inline-flex items-center justify-center gap-2 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90'
+          className='inline-flex items-center justify-center gap-2 rounded-md bg-purple-900 px-4 py-2 text-sm font-medium text-gray-100 transition-colors duration-200 hover:bg-purple-800'
         >
-          Return to Dashboard
-          <ArrowRightIcon className='h-4 w-4' />
+          Back to Dotabod
+          <ArrowRightIcon className='h-4 w-4' aria-hidden />
         </Link>
-      </div>
+      </motion.div>
     </div>
   )
 }


### PR DESCRIPTION
Reworks the `/gift` and `/[username]/gift` surface plus the gift-success page.

## What changed
- **Hero + layout:** real headline, two-column form with a sticky live chat preview, replacing the flat stack of gray cards.
- **Live price summary:** preset durations (1/3/6/12 months) and a running total, so the buyer sees what they'll pay before checkout. The CTA now shows the total (the old `_calculateTotalPrice` was computed and thrown away).
- **Tighter info:** the two prose cards became a scannable "What you're unlocking" / "How it works" pair.
- **Sentence case** throughout, reduced-motion-safe entrance and confetti.

## Removed the stream-overlay promise
Overlay delivery was removed for being inefficient, so the gift pages no longer show or promise it:
- Dropped the overlay preview (`GiftSubscriptionAlert`) from both the form preview and the success page.
- Updated copy everywhere it promised the overlay; the gift now only promises the Twitch chat message.
- Updated the `GiftPreview` test to match.

## Housekeeping
- Ignore local agent skill installs and `.playwright-mcp/` output.

Verified both pages render in-browser; full pre-commit suite (format, lint, 289 tests, typecheck) passes.