### PR TITLE
Fix gift-success showing wrong details; drop on-stream copy

### DIFF
--- a/src/pages/api/stripe/create-gift-checkout.ts
+++ b/src/pages/api/stripe/create-gift-checkout.ts
@@ -112,13 +112,25 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       })
     }
 
-    // Create a checkout session for the gift
-    const baseUrl = process.env.NEXTAUTH_URL ?? 'https://dotabod.com'
-    const successUrl = `${baseUrl}/gift-success?recipient=${encodeURIComponent(recipientUser.name || recipientUser.displayName || '')}`
-    const cancelUrl = `${baseUrl}/gift?canceled=true`
-
     // Always use one-time payment mode for gift credits
     const finalQuantity = quantity
+
+    // Create a checkout session for the gift
+    const baseUrl = process.env.NEXTAUTH_URL ?? 'https://dotabod.com'
+    // Pass the gift details through so the success page can show what was
+    // purchased. Quantity reflects the selection at checkout; a buyer who
+    // adjusts it inside Stripe may see a slightly different number here.
+    const successParams = new URLSearchParams({
+      recipient: recipientUser.name || recipientUser.displayName || '',
+      senderName: sanitizeInput(giftSenderName) || 'Anonymous',
+      quantity: finalQuantity.toString(),
+    })
+    const sanitizedGiftMessage = sanitizeInput(giftMessage)
+    if (sanitizedGiftMessage) {
+      successParams.set('giftMessage', sanitizedGiftMessage)
+    }
+    const successUrl = `${baseUrl}/gift-success?${successParams.toString()}`
+    const cancelUrl = `${baseUrl}/gift?canceled=true`
 
     // Get gift duration from price ID using GIFT_PRICE_IDS
     // Determine gift duration based on which price ID field matches

--- a/src/pages/api/stripe/create-gift-checkout.ts
+++ b/src/pages/api/stripe/create-gift-checkout.ts
@@ -117,19 +117,11 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
     // Create a checkout session for the gift
     const baseUrl = process.env.NEXTAUTH_URL ?? 'https://dotabod.com'
-    // Pass the gift details through so the success page can show what was
-    // purchased. Quantity reflects the selection at checkout; a buyer who
-    // adjusts it inside Stripe may see a slightly different number here.
-    const successParams = new URLSearchParams({
-      recipient: recipientUser.name || recipientUser.displayName || '',
-      senderName: sanitizeInput(giftSenderName) || 'Anonymous',
-      quantity: finalQuantity.toString(),
-    })
-    const sanitizedGiftMessage = sanitizeInput(giftMessage)
-    if (sanitizedGiftMessage) {
-      successParams.set('giftMessage', sanitizedGiftMessage)
-    }
-    const successUrl = `${baseUrl}/gift-success?${successParams.toString()}`
+    // Pass only the Stripe session id. The success page reads the gift
+    // details from the session metadata server-side, so the recipient's
+    // name and the buyer's personal message never land in the URL, browser
+    // history, or request logs.
+    const successUrl = `${baseUrl}/gift-success?session_id={CHECKOUT_SESSION_ID}`
     const cancelUrl = `${baseUrl}/gift?canceled=true`
 
     // Get gift duration from price ID using GIFT_PRICE_IDS
@@ -168,6 +160,8 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         isGift: 'true',
         recipientUserId: recipientUser.id,
         recipientUsername,
+        // Friendly name for the success page (prefers display name over login).
+        recipientDisplayName: recipientUser.displayName || recipientUser.name || '',
         giftDuration,
         giftMessage: sanitizeInput(giftMessage),
         giftSenderName: sanitizeInput(giftSenderName) || 'Anonymous',

--- a/src/pages/gift-success.tsx
+++ b/src/pages/gift-success.tsx
@@ -135,7 +135,7 @@ const GiftSuccessPage: NextPageWithLayout = () => {
               <span className='font-medium text-gray-200'>1 to 3 minutes</span> to reach the
               recipient's Twitch chat.
             </p>
-            <p>If they're live right now, your gift will show up on stream shortly.</p>
+            <p>If they're live right now, it'll appear in their Twitch chat shortly.</p>
           </div>
         </Card>
       </motion.div>

--- a/src/pages/gift-success.tsx
+++ b/src/pages/gift-success.tsx
@@ -1,12 +1,13 @@
 import confetti from 'canvas-confetti'
 import { motion, useReducedMotion } from 'framer-motion'
 import { ArrowRightIcon, CheckIcon, ClockIcon, GiftIcon } from 'lucide-react'
+import type { GetServerSideProps } from 'next'
 import Link from 'next/link'
-import { useRouter } from 'next/router'
 import type { ReactElement } from 'react'
 import { useEffect, useState } from 'react'
 import HomepageShell from '@/components/Homepage/HomepageShell'
 import TwitchChat from '@/components/TwitchChat'
+import { stripe } from '@/lib/stripe-server'
 import type { NextPageWithLayout } from '@/pages/_app'
 import { Card } from '@/ui/card'
 
@@ -16,16 +17,21 @@ const NEXT_STEPS = [
   'Already a Pro subscriber? Your credits stack onto their account and extend how long they keep Pro.',
 ]
 
-const GiftSuccessPage: NextPageWithLayout = () => {
-  const router = useRouter()
-  const { recipient, senderName, quantity, giftMessage } = router.query
+interface GiftSuccessProps {
+  recipient: string
+  senderName: string
+  quantity: number
+  giftMessage: string
+}
+
+const GiftSuccessPage: NextPageWithLayout<GiftSuccessProps> = ({
+  recipient,
+  senderName: formattedSenderName,
+  quantity: parsedQuantity,
+  giftMessage: formattedGiftMessage,
+}) => {
   const [hasCelebrated, setHasCelebrated] = useState(false)
   const reduceMotion = useReducedMotion()
-
-  // Parse quantity to a number (default to 1 if undefined or invalid)
-  const parsedQuantity = Number.parseInt(quantity as string, 10) || 1
-  const formattedSenderName = (senderName as string) || 'Anonymous'
-  const formattedGiftMessage = (giftMessage as string) || ''
 
   const fadeUp = (delay: number) => ({
     initial: reduceMotion ? false : { opacity: 0, y: 14 },
@@ -205,6 +211,48 @@ GiftSuccessPage.getLayout = function getLayout(page: ReactElement) {
       {page}
     </HomepageShell>
   )
+}
+
+export const getServerSideProps: GetServerSideProps<GiftSuccessProps> = async ({ query }) => {
+  const fallback: GiftSuccessProps = {
+    recipient: '',
+    senderName: 'Anonymous',
+    quantity: 1,
+    giftMessage: '',
+  }
+
+  const sessionId = typeof query.session_id === 'string' ? query.session_id : null
+  if (!sessionId) {
+    return { props: fallback }
+  }
+
+  try {
+    const session = await stripe.checkout.sessions.retrieve(sessionId, {
+      expand: ['line_items'],
+    })
+
+    if (session.metadata?.isGift !== 'true') {
+      return { props: fallback }
+    }
+
+    // Prefer the real purchased quantity from the line item, since Stripe's
+    // adjustable quantity lets the buyer change it during checkout.
+    const lineQuantity = session.line_items?.data?.[0]?.quantity ?? undefined
+    const metaQuantity = Number.parseInt(session.metadata?.giftQuantity ?? '', 10)
+    const quantity = lineQuantity || (Number.isNaN(metaQuantity) ? 1 : metaQuantity) || 1
+
+    return {
+      props: {
+        recipient:
+          session.metadata?.recipientDisplayName || session.metadata?.recipientUsername || '',
+        senderName: session.metadata?.giftSenderName || 'Anonymous',
+        quantity,
+        giftMessage: session.metadata?.giftMessage || '',
+      },
+    }
+  } catch {
+    return { props: fallback }
+  }
 }
 
 export default GiftSuccessPage


### PR DESCRIPTION
Follow-up addressing all of Copilot's review comments (from #240 and this PR's own review).

## 1. Success page showed default details (bug)
The success page reads recipient, sender, quantity, and message, but the checkout only passed `recipient` in the URL, so every gift landed showing `1 month` / `Anonymous` / no message.

**Fix (robust):** `success_url` now carries only `{CHECKOUT_SESSION_ID}`. The success page reads the gift details from the Stripe session via `getServerSideProps`. This also means:
- **Quantity is accurate** even when the buyer adjusts it during Stripe checkout (read from the actual line item, not pre-checkout metadata).
- **No PII in the URL** — the buyer's personal message and the recipient name never hit the URL, browser history, or request logs (addresses the privacy comment).
- **Friendlier recipient name** — shows display name over login via new `recipientDisplayName` metadata.
- Falls back to safe defaults when the session is missing or isn't a gift.

## 2. Copy still promised on-stream delivery
`gift-success.tsx` said the gift would "show up on stream." Reworded to point at Twitch chat, consistent with removing the overlay promise in #240.

## Notes
- Verified the success page renders on the fallback path (no session id) without error; a real checkout populates details from session metadata.
- Full pre-commit suite (format, lint, 289 tests, typecheck) passes.