### PR TITLE
Add streamers directory + boost its discoverability

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://dotabod.com/sitemap.xml

--- a/src/components/Homepage/Header.tsx
+++ b/src/components/Homepage/Header.tsx
@@ -60,6 +60,7 @@ export const Header: FC = () => (
                         className='absolute inset-x-0 top-0 z-0 origin-top rounded-b-2xl bg-gray-800 px-6 pb-6 pt-32 shadow-2xl shadow-gray-900/20'
                       >
                         <div className='space-y-4'>
+                          <MobileNavLink href='/streamers'>Streamers</MobileNavLink>
                           <MobileNavLink href='/#features'>Features</MobileNavLink>
                           <MobileNavLink href='/#pricing'>Pricing</MobileNavLink>
                           <MobileNavLink href='/gift'>

--- a/src/components/Homepage/Hero.tsx
+++ b/src/components/Homepage/Hero.tsx
@@ -250,6 +250,15 @@ export function Hero() {
                 ) : (
                   <p className='text-center text-gray-300'>No top streamers found</p>
                 )}
+                <div className='mt-4 text-center lg:text-left'>
+                  <Link
+                    href='/streamers'
+                    onClick={() => track('homepage - browse all streamers')}
+                    className='text-sm font-medium text-purple-300 transition-colors hover:text-purple-200'
+                  >
+                    Browse all live streamers →
+                  </Link>
+                </div>
               </div>
             </div>
           </div>

--- a/src/components/NavLinks.tsx
+++ b/src/components/NavLinks.tsx
@@ -28,6 +28,7 @@ export const NavLinks: FC<NavLinksProps> = ({ bottom = false }) => {
   }
 
   return [
+    ['Streamers', '/streamers', 'Browse Dota 2 streamers live right now'],
     ['Pricing', '/#pricing'],
     ['Blog', '/blog'],
     ['Gift Pro', '/gift', 'Gift Dotabod Pro to your favorite streamer'],

--- a/src/components/Streamers/StreamerCard.tsx
+++ b/src/components/Streamers/StreamerCard.tsx
@@ -1,0 +1,102 @@
+import Link from 'next/link'
+import type { FC } from 'react'
+import { Badge } from '@/components/Badge'
+import { getRankDetail, getRankImage, type StreamerTier } from '@/lib/ranks'
+
+export interface StreamerSummary {
+  name: string
+  displayName: string | null
+  image: string | null
+  mmr: number
+  followers: number | null
+  standing: number | null
+  tier: StreamerTier
+  isLive: boolean
+  // Relative time since the streamer's most recent tracked match (e.g. "3h ago"), shown on
+  // offline cards so the roster reads as recently-active rather than stale. Null when live.
+  lastMatchLabel: string | null
+}
+
+const DEFAULT_AVATAR = '/images/hero/default.png'
+
+export const StreamerCard: FC<{ streamer: StreamerSummary }> = ({ streamer }) => {
+  const { name, displayName, image, mmr, standing, isLive, lastMatchLabel } = streamer
+  const rank = getRankDetail(mmr, standing)
+  const medal = rank ? getRankImage(rank as Parameters<typeof getRankImage>[0]) : null
+  const label = displayName || name
+
+  return (
+    <div className='group relative flex flex-col rounded-lg border border-transparent bg-gray-900 p-4 shadow-lg transition-colors duration-200 hover:border-gray-600 motion-safe:hover:shadow-gray-500/10'>
+      <div className='flex items-start gap-3'>
+        <div className='flex-shrink-0'>
+          <img
+            src={image || DEFAULT_AVATAR}
+            onError={(e) => {
+              e.currentTarget.src = DEFAULT_AVATAR
+            }}
+            alt=''
+            width={56}
+            height={56}
+            className={`h-14 w-14 rounded-full object-cover ring-2 ${
+              isLive ? 'ring-red-500/60' : 'ring-gray-700'
+            }`}
+          />
+        </div>
+
+        <div className='min-w-0 flex-grow'>
+          <div className='flex items-center gap-2'>
+            <Link
+              href={`/${name}`}
+              className='truncate font-medium text-gray-100! after:absolute after:inset-0 hover:text-gray-100'
+            >
+              {label}
+            </Link>
+            {isLive && (
+              <span className='flex flex-shrink-0 items-center gap-1 rounded-md bg-red-700 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-white'>
+                <span className='h-1.5 w-1.5 rounded-full bg-white motion-safe:animate-pulse' />
+                Live
+              </span>
+            )}
+          </div>
+          <p className='truncate text-xs text-gray-400'>@{name}</p>
+          {!isLive && lastMatchLabel && (
+            <p className='truncate text-xs text-gray-500'>Last played {lastMatchLabel}</p>
+          )}
+        </div>
+      </div>
+
+      <div className='mt-4 flex items-center justify-between gap-3'>
+        <div className='flex min-h-8 items-center gap-2'>
+          {medal?.image ? (
+            <Badge
+              image={medal.image}
+              alt='Rank medal'
+              width={32}
+              height={32}
+              priority={false}
+              className='h-8 w-8 flex-shrink-0 object-contain'
+            />
+          ) : null}
+          <div className='leading-tight'>
+            {standing ? (
+              <span className='text-sm font-medium text-gray-200'>Immortal #{standing}</span>
+            ) : mmr > 0 ? (
+              <span className='text-sm font-medium text-gray-200'>{mmr.toLocaleString()} MMR</span>
+            ) : (
+              <span className='text-sm text-gray-500'>Unranked</span>
+            )}
+          </div>
+        </div>
+
+        <a
+          href={`https://twitch.tv/${name}`}
+          target='_blank'
+          rel='noopener noreferrer'
+          className='relative z-10 flex min-h-11 flex-shrink-0 items-center rounded-md bg-purple-800 px-4 text-sm font-medium text-gray-100 transition-colors duration-200 hover:bg-purple-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-purple-400 sm:min-h-0 sm:px-3 sm:py-1.5 sm:text-xs'
+        >
+          Watch
+        </a>
+      </div>
+    </div>
+  )
+}

--- a/src/components/Streamers/StreamersDirectory.tsx
+++ b/src/components/Streamers/StreamersDirectory.tsx
@@ -1,0 +1,290 @@
+import { Select } from 'antd'
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { StreamerCard, type StreamerSummary } from '@/components/Streamers/StreamerCard'
+import {
+  type StreamerTier,
+  tierDisplayOrder,
+  tierEmblem,
+  tierLabel,
+  tierRangeLabel,
+} from '@/lib/ranks'
+
+export type SortKey = 'mmr_desc' | 'mmr_asc' | 'followers_desc'
+
+const sortOptions: { label: string; value: SortKey }[] = [
+  { label: 'MMR: high to low', value: 'mmr_desc' },
+  { label: 'MMR: low to high', value: 'mmr_asc' },
+  { label: 'Most followers', value: 'followers_desc' },
+]
+
+const comparators: Record<SortKey, (a: StreamerSummary, b: StreamerSummary) => number> = {
+  mmr_desc: (a, b) => b.mmr - a.mmr,
+  mmr_asc: (a, b) => a.mmr - b.mmr,
+  followers_desc: (a, b) => (b.followers ?? -1) - (a.followers ?? -1),
+}
+
+// Immortal sorts by standing (best first) regardless of the chosen MMR sort, since the
+// leaderboard number is the meaningful ranking there.
+const immortalComparator = (a: StreamerSummary, b: StreamerSummary): number => {
+  const sa = a.standing ?? Number.POSITIVE_INFINITY
+  const sb = b.standing ?? Number.POSITIVE_INFINITY
+  if (sa !== sb) {
+    return sa - sb
+  }
+  return b.mmr - a.mmr
+}
+
+interface Group {
+  tier: StreamerTier
+  streamers: StreamerSummary[]
+}
+
+const buildGroups = (streamers: StreamerSummary[], sort: SortKey): Group[] => {
+  const byTier = new Map<StreamerTier, StreamerSummary[]>()
+  for (const streamer of streamers) {
+    const bucket = byTier.get(streamer.tier)
+    if (bucket) {
+      bucket.push(streamer)
+    } else {
+      byTier.set(streamer.tier, [streamer])
+    }
+  }
+  return tierDisplayOrder
+    .filter((tier) => byTier.has(tier))
+    .map((tier) => ({
+      tier,
+      streamers: byTier
+        .get(tier)!
+        .slice()
+        .sort(tier === 'immortal' ? immortalComparator : comparators[sort]),
+    }))
+}
+
+// One rank bucket: emblem + label header, then a responsive grid of cards. The roster view
+// passes a sectionRef so the jump rail can scroll to and highlight it; the "Live now" view
+// passes none. Heading ids are namespaced (idPrefix) to stay unique across both views.
+const TierGroupSection = ({
+  group,
+  idPrefix,
+  railHeight,
+  sectionRef,
+}: {
+  group: Group
+  idPrefix: string
+  railHeight: number
+  sectionRef?: (el: HTMLElement | null) => void
+}) => {
+  const headingId = `${idPrefix}tier-${group.tier}`
+  return (
+    <section
+      data-tier={sectionRef ? group.tier : undefined}
+      ref={sectionRef}
+      style={{ scrollMarginTop: railHeight + 16 }}
+      aria-labelledby={headingId}
+    >
+      <div className='mb-5 flex items-center gap-3 border-b border-gray-800 pb-3'>
+        <img
+          src={`/images/ranks/${tierEmblem[group.tier]}`}
+          alt=''
+          width={36}
+          height={36}
+          className='h-9 w-9 flex-shrink-0 object-contain'
+        />
+        <div className='flex-1'>
+          <h3 id={headingId} className='text-lg font-semibold leading-tight text-gray-100'>
+            {tierLabel[group.tier]}
+          </h3>
+          <p className='text-xs text-gray-500'>{tierRangeLabel(group.tier)}</p>
+        </div>
+        <span className='text-sm tabular-nums text-gray-400'>{group.streamers.length}</span>
+      </div>
+      <div className='grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4'>
+        {group.streamers.map((streamer) => (
+          <StreamerCard key={streamer.name} streamer={streamer} />
+        ))}
+      </div>
+    </section>
+  )
+}
+
+export const StreamersDirectory = ({
+  live,
+  roster,
+}: {
+  live: StreamerSummary[]
+  roster: StreamerSummary[]
+}) => {
+  const [sort, setSort] = useState<SortKey>('mmr_desc')
+  const [activeTier, setActiveTier] = useState<StreamerTier | null>(null)
+
+  // The sticky rail grows taller as the pills wrap onto more rows, so its height is measured
+  // rather than assumed: it sets both the scroll-into-view offset and the scroll-spy trigger
+  // line. Without this, jumping to a tier leaves its header hidden behind the wrapped rail.
+  const railRef = useRef<HTMLDivElement>(null)
+  const [railHeight, setRailHeight] = useState(0)
+  useEffect(() => {
+    const el = railRef.current
+    if (!el) {
+      return
+    }
+    const observer = new ResizeObserver(() => setRailHeight(el.offsetHeight))
+    observer.observe(el)
+    return () => observer.disconnect()
+  }, [])
+
+  const liveGroups = useMemo<Group[]>(() => buildGroups(live, sort), [live, sort])
+  const rosterGroups = useMemo<Group[]>(() => buildGroups(roster, sort), [roster, sort])
+
+  // Scroll-spy: highlight the roster tier whose section is nearest the top of the viewport.
+  const sectionRefs = useRef(new Map<StreamerTier, HTMLElement>())
+  useEffect(() => {
+    const observer = new IntersectionObserver(
+      (entries) => {
+        const visible = entries
+          .filter((e) => e.isIntersecting)
+          .sort((a, b) => a.boundingClientRect.top - b.boundingClientRect.top)
+        if (visible[0]) {
+          setActiveTier(visible[0].target.getAttribute('data-tier') as StreamerTier)
+        }
+      },
+      // Bias the trigger line just below the sticky rail so the active chip flips as a
+      // section header reaches it, not when it barely enters the viewport.
+      { rootMargin: `-${railHeight + 8}px 0px -65% 0px`, threshold: 0 },
+    )
+    for (const el of sectionRefs.current.values()) {
+      observer.observe(el)
+    }
+    return () => observer.disconnect()
+  }, [rosterGroups, railHeight])
+
+  const jumpTo = (tier: StreamerTier) => {
+    const el = sectionRefs.current.get(tier)
+    if (!el) {
+      return
+    }
+    const reduce = window.matchMedia('(prefers-reduced-motion: reduce)').matches
+    el.scrollIntoView({ behavior: reduce ? 'auto' : 'smooth', block: 'start' })
+    setActiveTier(tier)
+  }
+
+  return (
+    <>
+      {/* Currently live streamers, grouped by rank, sitting above the full directory so
+          they're the first thing visitors see when anyone is playing. */}
+      {liveGroups.length > 0 && (
+        <section aria-labelledby='live-now-heading' className='mb-14'>
+          <h2 id='live-now-heading' className='mb-6 text-xl font-bold text-gray-100'>
+            Live now
+          </h2>
+          <div className='space-y-12'>
+            {liveGroups.map((group) => (
+              <TierGroupSection
+                key={group.tier}
+                group={group}
+                idPrefix='live-'
+                railHeight={railHeight}
+              />
+            ))}
+          </div>
+        </section>
+      )}
+
+      <h2 className='mb-1 text-xl font-bold text-gray-100'>Browse offline streamers by rank</h2>
+      <p className='mb-6 text-sm text-gray-500'>
+        Recently active streamers who aren&apos;t live right now. Jump to your bracket to find
+        someone to follow.
+      </p>
+
+      {/* Sticky rank rail: jump-nav with per-rank counts for the full roster below.
+          On phones it spans edge to edge and the pills wrap onto multiple rows; on pointer
+          screens it becomes a bordered panel sharing a row with the sort control. */}
+      <div
+        ref={railRef}
+        className='sticky top-0 z-20 -mx-4 mb-8 border-b border-gray-800 bg-gray-900/95 px-4 py-2 backdrop-blur-sm sm:mx-0 sm:mb-10 sm:rounded-lg sm:border sm:px-3 sm:py-3'
+      >
+        <div className='flex min-w-0 items-center gap-3'>
+          {/* Pills wrap instead of scrolling so every rank stays visible on a phone;
+              min-w-0 lets this flex child shrink to the viewport width. */}
+          <nav
+            aria-label='Jump to rank'
+            className='-my-1 flex min-w-0 flex-1 flex-wrap gap-1.5 py-1'
+          >
+            {rosterGroups.map(({ tier, streamers: group }) => {
+              const active = activeTier === tier
+              return (
+                <button
+                  key={tier}
+                  type='button'
+                  onClick={() => jumpTo(tier)}
+                  aria-current={active ? 'true' : undefined}
+                  className={`group flex min-h-9 flex-shrink-0 items-center gap-1.5 rounded-full border px-3 py-2 text-sm font-medium transition-colors duration-200 sm:min-h-0 sm:px-2.5 sm:py-1 sm:text-xs ${
+                    active
+                      ? 'border-purple-500/60 bg-purple-500/15 text-purple-200'
+                      : 'border-transparent bg-gray-800 text-gray-300 hover:bg-gray-700 hover:text-gray-100'
+                  }`}
+                >
+                  <img
+                    src={`/images/ranks/${tierEmblem[tier]}`}
+                    alt=''
+                    width={18}
+                    height={18}
+                    className='h-[18px] w-[18px] flex-shrink-0 object-contain'
+                  />
+                  <span>{tierLabel[tier]}</span>
+                  <span
+                    className={`tabular-nums ${active ? 'text-purple-300/80' : 'text-gray-500'}`}
+                  >
+                    {group.length}
+                  </span>
+                </button>
+              )
+            })}
+          </nav>
+          <Select<SortKey>
+            value={sort}
+            onChange={setSort}
+            options={sortOptions}
+            size='small'
+            variant='borderless'
+            className='hidden flex-shrink-0 sm:block'
+            style={{ width: 168 }}
+            aria-label='Sort streamers within each rank'
+          />
+        </div>
+      </div>
+
+      {/* Mobile sort, below the rail so the rank pills get full width up top. Large size
+          gives it a 40px touch target; the label clarifies the bare control. */}
+      <div className='mb-8 flex items-center justify-end gap-2 sm:hidden'>
+        <span className='text-xs text-gray-500'>Sort</span>
+        <Select<SortKey>
+          value={sort}
+          onChange={setSort}
+          options={sortOptions}
+          size='large'
+          aria-label='Sort streamers within each rank'
+          popupMatchSelectWidth={false}
+          className='w-48'
+        />
+      </div>
+
+      <div className='space-y-12'>
+        {rosterGroups.map((group) => (
+          <TierGroupSection
+            key={group.tier}
+            group={group}
+            idPrefix=''
+            railHeight={railHeight}
+            sectionRef={(el) => {
+              if (el) {
+                sectionRefs.current.set(group.tier, el)
+              } else {
+                sectionRefs.current.delete(group.tier)
+              }
+            }}
+          />
+        ))}
+      </div>
+    </>
+  )
+}

--- a/src/lib/ranks.ts
+++ b/src/lib/ranks.ts
@@ -119,6 +119,44 @@ export function getRankImage(rank: RankType) {
   }
 }
 
+// Rank tiers in ascending order. Each tier's position (1-based) is the medal digit used
+// in the `ranks` images (1 = Herald ... 7 = Divine). Immortal sits above the highest
+// non-leaderboard rank.
+export const rankTiers = [
+  { key: 'herald' },
+  { key: 'guardian' },
+  { key: 'crusader' },
+  { key: 'archon' },
+  { key: 'legend' },
+  { key: 'ancient' },
+  { key: 'divine' },
+  { key: 'immortal' },
+] as const
+
+export type RankTierKey = (typeof rankTiers)[number]['key']
+
+// Maps a tier key to the MMR bounds used for filtering. Immortal has no upper bound
+// and starts one point above Divine☆5. Returns null for an unknown tier.
+export function tierMmrRange(key: string): { gte?: number; lte?: number } | null {
+  if (key === 'immortal') {
+    const divineMax = ranks.at(-1)?.range[1] ?? 0
+    return { gte: divineMax + 1 }
+  }
+  const index = rankTiers.findIndex((t) => t.key === key)
+  if (index === -1) {
+    return null
+  }
+  // The tier's 1-based position is the leading medal digit in its `ranks` image filenames.
+  const group = ranks.filter((rank) => Number(rank.image[0]) === index + 1)
+  if (group.length === 0) {
+    return null
+  }
+  // mmr 0 is the default for users with no tracked MMR (uncalibrated), not a genuine
+  // Herald, so the lowest tier starts at 1 to keep unknown-rank users out of rank buckets.
+  const lo = group[0].range[0]
+  return { gte: lo === 0 ? 1 : lo, lte: group.at(-1)?.range[1] }
+}
+
 export function getRankTitle(rankTier?: string | number): string {
   if (!rankTier || Number(rankTier) === 0) {
     return 'Uncalibrated'
@@ -140,4 +178,85 @@ export function getRankTitle(rankTier?: string | number): string {
   )
 
   return rank?.title ?? 'Unknown'
+}
+
+// --- Streamers directory grouping --------------------------------------------
+
+export type StreamerTier = RankTierKey | 'unranked'
+
+// Highest tier first, with uncalibrated streamers collected at the end so nobody
+// silently drops off the directory.
+export const tierDisplayOrder: StreamerTier[] = [
+  'immortal',
+  'divine',
+  'ancient',
+  'legend',
+  'archon',
+  'crusader',
+  'guardian',
+  'herald',
+  'unranked',
+]
+
+// One representative medal per tier for section headers: the 5-star medal of the
+// bracket, the low-immortal medal for Immortal, the empty medal for uncalibrated.
+export const tierEmblem: Record<StreamerTier, string> = {
+  immortal: '80.png',
+  divine: '75.png',
+  ancient: '65.png',
+  legend: '55.png',
+  archon: '45.png',
+  crusader: '35.png',
+  guardian: '25.png',
+  herald: '15.png',
+  unranked: '0.png',
+}
+
+export const tierLabel: Record<StreamerTier, string> = {
+  immortal: 'Immortal',
+  divine: 'Divine',
+  ancient: 'Ancient',
+  legend: 'Legend',
+  archon: 'Archon',
+  crusader: 'Crusader',
+  guardian: 'Guardian',
+  herald: 'Herald',
+  unranked: 'Uncalibrated',
+}
+
+// Resolve a streamer into a single tier bucket. Immortal is a leaderboard standing
+// (or MMR above Divine); mmr<=0 means uncalibrated, not Herald.
+export function tierForRank(mmr: number, standing: number | null): StreamerTier {
+  const divineMax = ranks.at(-1)?.range[1] ?? 5629
+  if ((standing && standing > 0) || mmr > divineMax) {
+    return 'immortal'
+  }
+  if (!mmr || mmr <= 0) {
+    return 'unranked'
+  }
+  const tier = rankTiers.find((t) => {
+    if (t.key === 'immortal') {
+      return false
+    }
+    const range = tierMmrRange(t.key)
+    return (
+      range != null && mmr >= (range.gte ?? 0) && mmr <= (range.lte ?? Number.POSITIVE_INFINITY)
+    )
+  })
+  return (tier?.key as StreamerTier) ?? 'unranked'
+}
+
+// Human-readable MMR band shown under each section header.
+export function tierRangeLabel(tier: StreamerTier): string {
+  if (tier === 'immortal') {
+    return 'Leaderboard'
+  }
+  if (tier === 'unranked') {
+    return 'MMR not tracked'
+  }
+  const range = tierMmrRange(tier)
+  if (!range) {
+    return ''
+  }
+  return `${(range.gte ?? 0).toLocaleString()}–${(range.lte ?? 0).toLocaleString()} MMR`
 }

--- a/src/pages/[username].tsx
+++ b/src/pages/[username].tsx
@@ -448,6 +448,14 @@ const PageContent = ({
               Set up Dotabod for free
             </Button>
           </Link>
+          <p className='mt-4 text-sm'>
+            <Link
+              href='/streamers'
+              className='font-medium text-purple-300 transition-colors hover:text-purple-200'
+            >
+              Browse more Dota 2 streamers →
+            </Link>
+          </p>
         </div>
       </Container>
     </>
@@ -511,6 +519,18 @@ const CommandsPage = ({ userData, subscriptionInfo, username }: UserProfileProps
   const pageTitle = `${userData.displayName || userData.name} - ${userData.mmr || 0} MMR | Dotabod`
   const pageDescription = `View ${userData.displayName || userData.name}'s Dota 2 commands and stream stats on Dotabod. ${userData.stream_online ? 'Currently live streaming!' : 'Stream offline.'}`
 
+  const profileJsonLd = {
+    '@context': 'https://schema.org',
+    '@type': 'ProfilePage',
+    url: `https://dotabod.com/${username}`,
+    mainEntity: {
+      '@type': 'Person',
+      name: userData.displayName || userData.name,
+      url: `https://twitch.tv/${userData.name}`,
+      ...(userData.image ? { image: userData.image } : {}),
+    },
+  }
+
   return (
     <>
       <Head>
@@ -525,6 +545,10 @@ const CommandsPage = ({ userData, subscriptionInfo, username }: UserProfileProps
         <meta property='twitter:description' content={pageDescription} />
         <meta property='twitter:image' content={userData.image || '/images/hero/default.png'} />
         <link rel='canonical' href={`https://dotabod.com/${username}`} />
+        <script
+          type='application/ld+json'
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(profileJsonLd) }}
+        />
       </Head>
       <HomepageShell
         dontUseTitle

--- a/src/pages/sitemaps/static.xml.tsx
+++ b/src/pages/sitemaps/static.xml.tsx
@@ -14,6 +14,12 @@ export const getServerSideProps: GetServerSideProps = async ({ res }) => {
         url: 'https://dotabod.com',
       },
       {
+        changefreq: 'daily',
+        lastmod: new Date().toISOString(),
+        priority: '0.8',
+        url: 'https://dotabod.com/streamers',
+      },
+      {
         changefreq: 'monthly',
         lastmod: new Date().toISOString(),
         priority: '0.7',

--- a/src/pages/streamers.tsx
+++ b/src/pages/streamers.tsx
@@ -1,0 +1,244 @@
+import type { Prisma } from '@prisma/client'
+import { Empty } from 'antd'
+import type { GetServerSideProps } from 'next'
+import Head from 'next/head'
+import type { ReactElement } from 'react'
+import { Container } from '@/components/Container'
+import HomepageShell from '@/components/Homepage/HomepageShell'
+import type { StreamerSummary } from '@/components/Streamers/StreamerCard'
+import { StreamersDirectory } from '@/components/Streamers/StreamersDirectory'
+import prisma from '@/lib/db'
+import { tierForRank } from '@/lib/ranks'
+import type { NextPageWithLayout } from '@/pages/_app'
+
+interface StreamersPageProps {
+  live: StreamerSummary[]
+  roster: StreamerSummary[]
+}
+
+type StreamAccount = { steam32Id: number; mmr: number; leaderboard_rank: number | null }
+
+type StreamerRow = {
+  name: string
+  displayName: string | null
+  image: string | null
+  mmr: number
+  followers: number | null
+  steam32Id: number | null
+  SteamAccount: StreamAccount[]
+  matches: { updated_at: Date | null }[]
+}
+
+// Compact relative time ("just now", "3h ago", "2d ago") computed on the server against a
+// single `now`, so offline cards read as recently-active without any client date use.
+const formatRelativeAgo = (from: Date, now: number): string => {
+  const sec = Math.max(0, Math.floor((now - from.getTime()) / 1000))
+  if (sec < 60) {
+    return 'just now'
+  }
+  const min = Math.floor(sec / 60)
+  if (min < 60) {
+    return `${min}m ago`
+  }
+  const hr = Math.floor(min / 60)
+  if (hr < 24) {
+    return `${hr}h ago`
+  }
+  const day = Math.floor(hr / 24)
+  if (day < 7) {
+    return `${day}d ago`
+  }
+  return `${Math.floor(day / 7)}w ago`
+}
+
+// Pick the leaderboard standing for a user: prefer the Steam account matching their primary
+// steam32Id, otherwise the best (lowest) positive leaderboard rank across linked accounts.
+const pickStanding = (accounts: StreamAccount[], steam32Id: number | null): number | null => {
+  const primary = accounts.find((a) => a.steam32Id === steam32Id)?.leaderboard_rank
+  if (primary && primary > 0) {
+    return primary
+  }
+  const ranked = accounts
+    .map((a) => a.leaderboard_rank)
+    .filter((rank): rank is number => typeof rank === 'number' && rank > 0)
+  return ranked.length > 0 ? Math.min(...ranked) : null
+}
+
+// MMR lives on SteamAccount, not users.mmr (which is 0/unknown for nearly every streamer).
+// Mirror the overlay/dashboard: prefer the primary linked account, else the highest tracked
+// MMR across accounts, falling back to users.mmr only when no account has one.
+const pickMmr = (accounts: StreamAccount[], steam32Id: number | null, fallback: number): number => {
+  const primary = accounts.find((a) => a.steam32Id === steam32Id)?.mmr
+  if (primary && primary > 0) {
+    return primary
+  }
+  const best = Math.max(0, ...accounts.map((a) => a.mmr ?? 0))
+  return best > 0 ? best : fallback
+}
+
+const toSummary = (user: StreamerRow, isLive: boolean, now: number): StreamerSummary => {
+  const mmr = pickMmr(user.SteamAccount, user.steam32Id, user.mmr)
+  const standing = pickStanding(user.SteamAccount, user.steam32Id)
+  const lastMatch = user.matches[0]?.updated_at
+  return {
+    name: user.name,
+    displayName: user.displayName,
+    image: user.image,
+    mmr,
+    followers: user.followers,
+    standing,
+    tier: tierForRank(mmr, standing),
+    isLive,
+    lastMatchLabel: isLive || !lastMatch ? null : formatRelativeAgo(lastMatch, now),
+  }
+}
+
+const StreamersPage: NextPageWithLayout<StreamersPageProps> = ({ live, roster }) => {
+  const liveCount = live.length
+  const trackedCount = live.length + roster.length
+
+  // ItemList structured data so search engines read the directory as a list of streamer
+  // profiles. Capped so the markup stays small; the full roster is still in the HTML.
+  const jsonLd = {
+    '@context': 'https://schema.org',
+    '@type': 'CollectionPage',
+    name: 'Dota 2 streamers using Dotabod',
+    url: 'https://dotabod.com/streamers',
+    mainEntity: {
+      '@type': 'ItemList',
+      itemListElement: [...live, ...roster].slice(0, 50).map((streamer, index) => ({
+        '@type': 'ListItem',
+        position: index + 1,
+        item: {
+          '@type': 'ProfilePage',
+          name: streamer.displayName || streamer.name,
+          url: `https://dotabod.com/${streamer.name}`,
+          ...(streamer.image ? { image: streamer.image } : {}),
+        },
+      })),
+    },
+  }
+
+  return (
+    <Container className='py-10 sm:py-14'>
+      <Head>
+        <script
+          type='application/ld+json'
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+        />
+      </Head>
+
+      <header className='mb-8'>
+        <h1 className='text-3xl font-bold text-gray-100 sm:text-4xl'>Dota 2 streamers</h1>
+        <p className='mt-2 max-w-2xl text-sm text-gray-400'>
+          Dota 2 streamers running Dotabod, grouped by rank. Jump to your bracket to find someone at
+          your level, or start at the top with the pros. The Live now section refreshes as streamers
+          go live.
+        </p>
+        <p className='mt-3 text-sm text-gray-500'>
+          {liveCount === 0
+            ? 'No one is playing right now'
+            : `${liveCount.toLocaleString()} ${liveCount === 1 ? 'streamer' : 'streamers'} playing now`}
+          {trackedCount > 0
+            ? ` · ${trackedCount.toLocaleString()} ${trackedCount === 1 ? 'streamer' : 'streamers'} tracked`
+            : ''}
+        </p>
+      </header>
+
+      {trackedCount === 0 ? (
+        <div className='py-16'>
+          <Empty
+            image={Empty.PRESENTED_IMAGE_SIMPLE}
+            description={
+              <span className='text-gray-400'>No streamers to show yet. Check back soon.</span>
+            }
+          />
+        </div>
+      ) : (
+        <StreamersDirectory live={live} roster={roster} />
+      )}
+    </Container>
+  )
+}
+
+StreamersPage.getLayout = function getLayout(page: ReactElement) {
+  return (
+    <HomepageShell
+      seo={{
+        canonicalUrl: 'https://dotabod.com/streamers',
+        description:
+          'Browse Dota 2 streamers using Dotabod, grouped by rank from Herald to the Immortal leaderboard. See who is live on Twitch right now and find someone at your level to watch.',
+        title: 'Dota 2 streamers using Dotabod',
+        // The dynamic OG image endpoint is disabled (returns 410), so point at a static asset
+        // that actually renders in social cards.
+        ogImage: '/images/welcome.png',
+      }}
+    >
+      {page}
+    </HomepageShell>
+  )
+}
+
+export default StreamersPage
+
+const streamerSelect = {
+  name: true,
+  displayName: true,
+  image: true,
+  mmr: true,
+  followers: true,
+  steam32Id: true,
+  SteamAccount: {
+    select: { steam32Id: true, mmr: true, leaderboard_rank: true },
+  },
+  // Most recent tracked match, used to show "last played" on offline cards.
+  matches: {
+    orderBy: { updated_at: 'desc' },
+    take: 1,
+    select: { updated_at: true },
+  },
+} satisfies Prisma.UserSelect
+
+export const getServerSideProps: GetServerSideProps<StreamersPageProps> = async ({ res }) => {
+  // Cache at the edge so crawlers and bursts of visitors hit a warm response instead of the DB.
+  res.setHeader('Cache-Control', 'public, s-maxage=60, stale-while-revalidate=300')
+
+  const now = Date.now()
+  // Live: online AND a tracked match updated within the recency window, so we only badge
+  // streamers actually playing right now (mirrors the homepage featured-users query).
+  const liveMatchCutoff = new Date(now - 15 * 60 * 1000)
+  // Roster: anyone opted-in who has played recently, so the page is never empty for visitors
+  // or crawlers even when nobody is live.
+  const recentCutoff = new Date(now - 30 * 24 * 60 * 60 * 1000)
+
+  const liveUsers = await prisma.user.findMany({
+    where: {
+      stream_online: true,
+      hideFromLeaderboard: false,
+      bannedAt: null,
+      matches: { some: { updated_at: { gte: liveMatchCutoff } } },
+    },
+    select: streamerSelect,
+  })
+
+  const rosterUsers = await prisma.user.findMany({
+    where: {
+      hideFromLeaderboard: false,
+      bannedAt: null,
+      // Genuinely offline: excludes anyone in the Live now section above so the two
+      // sections never overlap and the "offline" label stays accurate.
+      stream_online: false,
+      matches: { some: { updated_at: { gte: recentCutoff } } },
+    },
+    orderBy: { followers: 'desc' },
+    take: 300,
+    select: streamerSelect,
+  })
+
+  return {
+    props: {
+      live: liveUsers.map((user) => toSummary(user, true, now)),
+      roster: rosterUsers.map((user) => toSummary(user, false, now)),
+    },
+  }
+}


### PR DESCRIPTION
Make /streamers durably crawlable and a hub that funnels visitors to streamers, rather than an often-empty "live now" page:

- Split into "Live now" + always-present "Browse offline streamers by rank" roster (recently active, capped at 300) so the page is never empty for users or crawlers
- Show "Last played Xh ago" on offline cards (computed server-side) so the roster reads as recently active, not stale
- StreamerCard live/offline variant; offline drops the LIVE badge/ring
- Edge cache the SSR response (s-maxage=60, swr=300)
- ItemList JSON-LD on /streamers and ProfilePage JSON-LD on /[username]
- Point og:image at a static asset (the og-image endpoint returns 410)
- Add robots.txt advertising the sitemap
- Internal links: homepage Hero and profile pages link to /streamers