### PR TITLE
feat: "What's New" surfaces + notifications consolidation

### DIFF
--- a/src/__tests__/components/NewFeaturesCard.test.tsx
+++ b/src/__tests__/components/NewFeaturesCard.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vite-plus/test'
+
+vi.mock('next/link', () => ({
+  default: ({ children, href }: any) => <a href={href}>{children}</a>,
+}))
+vi.mock('@/ui/card', () => ({
+  Card: ({ title, children }: any) => (
+    <div>
+      <h3>{title}</h3>
+      {children}
+    </div>
+  ),
+}))
+vi.mock('@/components/Dashboard/Features/TierSwitch', () => ({
+  TierSwitch: ({ label }: any) => <span>{label}</span>,
+}))
+
+import NewFeaturesCard from '@/components/Dashboard/Features/NewFeaturesCard'
+
+describe('NewFeaturesCard', () => {
+  it("renders the master toggle and links to What's New", () => {
+    render(<NewFeaturesCard />)
+
+    expect(screen.getByText('New features')).toBeInTheDocument()
+    expect(screen.getByText(/Automatically enable new features/)).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /See what's new/ })).toHaveAttribute(
+      'href',
+      '/dashboard/whats-new',
+    )
+  })
+})

--- a/src/__tests__/components/WhatsNewFeatureCard.test.tsx
+++ b/src/__tests__/components/WhatsNewFeatureCard.test.tsx
@@ -1,0 +1,73 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vite-plus/test'
+
+vi.mock('next/link', () => ({
+  default: ({ children, href }: any) => <a href={href}>{children}</a>,
+}))
+vi.mock('@/ui/card', () => ({
+  Card: ({ title, children }: any) => (
+    <div>
+      <h3>{title}</h3>
+      {children}
+    </div>
+  ),
+}))
+vi.mock('@/components/Dashboard/Features/TierSwitch', () => ({
+  TierSwitch: ({ label, checked }: any) => <span data-checked={String(checked)}>{label}</span>,
+}))
+vi.mock('@/lib/hooks/useUpdateSetting', () => ({
+  useUpdateSetting: vi.fn(() => ({ data: null, updateSetting: vi.fn() })),
+}))
+
+import WhatsNewFeatureCard from '@/components/Dashboard/Features/WhatsNewFeatureCard'
+import type { WhatsNewEntry } from '@/lib/whatsNew'
+
+const entry: WhatsNewEntry = {
+  id: 'demo',
+  title: 'Demo feature',
+  description: 'A demo feature.',
+  releaseDate: '2026-06-10',
+  category: 'chat',
+  settingKey: 'cosmeticsAnnounce',
+  followsNewFeatureMaster: true,
+  command: '!demo',
+  blogSlug: 'hello-world',
+  deepLink: { path: '/dashboard/x', section: 'y' },
+}
+
+describe('WhatsNewFeatureCard', () => {
+  it('renders title, command, latest badge, toggle (following master) and links', () => {
+    render(<WhatsNewFeatureCard entry={entry} master latest />)
+
+    expect(screen.getByText('Demo feature')).toBeInTheDocument()
+    expect(screen.getByText('!demo')).toBeInTheDocument()
+    expect(screen.getByText('Latest')).toBeInTheDocument()
+    // tri-state with no explicit value follows master (true)
+    expect(screen.getByText('Enabled')).toHaveAttribute('data-checked', 'true')
+    expect(screen.getByRole('link', { name: /Open settings/ })).toHaveAttribute(
+      'href',
+      '/dashboard/x#y',
+    )
+    expect(screen.getByRole('link', { name: /Read more/ })).toHaveAttribute(
+      'href',
+      '/blog/hello-world',
+    )
+  })
+
+  it('omits the toggle when the feature has no setting', () => {
+    render(
+      <WhatsNewFeatureCard
+        entry={{ ...entry, settingKey: undefined, followsNewFeatureMaster: false }}
+        master={false}
+      />,
+    )
+    expect(screen.queryByText('Enabled')).not.toBeInTheDocument()
+  })
+
+  it('hides the toggle in read-only mode (public changelog) but keeps links', () => {
+    render(<WhatsNewFeatureCard entry={entry} master readOnly />)
+    expect(screen.getByText('Demo feature')).toBeInTheDocument()
+    expect(screen.queryByText('Enabled')).not.toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /Read more/ })).toBeInTheDocument()
+  })
+})

--- a/src/__tests__/components/WhatsNewFeatureCard.test.tsx
+++ b/src/__tests__/components/WhatsNewFeatureCard.test.tsx
@@ -18,6 +18,14 @@ vi.mock('@/components/Dashboard/Features/TierSwitch', () => ({
 vi.mock('@/lib/hooks/useUpdateSetting', () => ({
   useUpdateSetting: vi.fn(() => ({ data: null, updateSetting: vi.fn() })),
 }))
+// The real CommandDetail pulls in next/image + chat components; stub the one key we exercise.
+vi.mock('@/components/Dashboard/CommandDetail', () => ({
+  default: {
+    commandNP: {
+      response: () => <div data-testid='command-demo'>!np with flag images</div>,
+    },
+  },
+}))
 
 import WhatsNewFeatureCard from '@/components/Dashboard/Features/WhatsNewFeatureCard'
 import type { WhatsNewEntry } from '@/lib/whatsNew'
@@ -68,6 +76,18 @@ describe('WhatsNewFeatureCard', () => {
     expect(screen.getByText(/How it works/, { selector: 'summary' })).toBeInTheDocument()
     expect(screen.getByText('First how-it-works paragraph.')).toBeInTheDocument()
     expect(screen.getByText('Second how-it-works paragraph.')).toBeInTheDocument()
+  })
+
+  it('renders the live command sample (with flag/emoji images) when demoCommand is set', () => {
+    render(
+      <WhatsNewFeatureCard
+        entry={{ ...entry, demoCommand: 'commandNP', demo: undefined }}
+        master
+      />,
+    )
+    expect(screen.getByTestId('command-demo')).toBeInTheDocument()
+    // the hand-copied demo.chat fallback is not used when a demoCommand is present
+    expect(screen.queryByText(/Pudge set captured/)).not.toBeInTheDocument()
   })
 
   it('omits the toggle when the feature has no setting', () => {

--- a/src/__tests__/components/WhatsNewFeatureCard.test.tsx
+++ b/src/__tests__/components/WhatsNewFeatureCard.test.tsx
@@ -32,7 +32,7 @@ const entry: WhatsNewEntry = {
   followsNewFeatureMaster: true,
   command: '!demo',
   blogSlug: 'hello-world',
-  deepLink: { path: '/dashboard/x', section: 'y' },
+  deepLink: { path: '/dashboard/commands', section: 'y' },
   demo: {
     chat: 'Pudge set captured! 3 cosmetics → dotabod.com/streamer/set',
     exampleUrl: 'https://dotabod.com/streamer/set',
@@ -50,9 +50,9 @@ describe('WhatsNewFeatureCard', () => {
     expect(screen.getByText('Latest')).toBeInTheDocument()
     // tri-state with no explicit value follows master (true)
     expect(screen.getByText('Enabled')).toHaveAttribute('data-checked', 'true')
-    expect(screen.getByRole('link', { name: /Open settings/ })).toHaveAttribute(
+    expect(screen.getByRole('link', { name: /Open commands/ })).toHaveAttribute(
       'href',
-      '/dashboard/x#y',
+      '/dashboard/commands#y',
     )
     expect(screen.getByRole('link', { name: /Read more/ })).toHaveAttribute(
       'href',

--- a/src/__tests__/components/WhatsNewFeatureCard.test.tsx
+++ b/src/__tests__/components/WhatsNewFeatureCard.test.tsx
@@ -33,6 +33,11 @@ const entry: WhatsNewEntry = {
   command: '!demo',
   blogSlug: 'hello-world',
   deepLink: { path: '/dashboard/x', section: 'y' },
+  demo: {
+    chat: 'Pudge set captured! 3 cosmetics → dotabod.com/streamer/set',
+    exampleUrl: 'https://dotabod.com/streamer/set',
+    exampleLabel: "See streamer's set page →",
+  },
 }
 
 describe('WhatsNewFeatureCard', () => {
@@ -51,6 +56,12 @@ describe('WhatsNewFeatureCard', () => {
     expect(screen.getByRole('link', { name: /Read more/ })).toHaveAttribute(
       'href',
       '/blog/hello-world',
+    )
+    // demo: sample chat + live example link
+    expect(screen.getByText(/Pudge set captured! 3 cosmetics/)).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /See streamer's set page/ })).toHaveAttribute(
+      'href',
+      'https://dotabod.com/streamer/set',
     )
   })
 

--- a/src/__tests__/components/WhatsNewFeatureCard.test.tsx
+++ b/src/__tests__/components/WhatsNewFeatureCard.test.tsx
@@ -38,6 +38,7 @@ const entry: WhatsNewEntry = {
     exampleUrl: 'https://dotabod.com/streamer/set',
     exampleLabel: "See streamer's set page →",
   },
+  details: ['First how-it-works paragraph.', 'Second how-it-works paragraph.'],
 }
 
 describe('WhatsNewFeatureCard', () => {
@@ -63,6 +64,10 @@ describe('WhatsNewFeatureCard', () => {
       'href',
       'https://dotabod.com/streamer/set',
     )
+    // collapsible "How it works" details (content is in the DOM even while collapsed)
+    expect(screen.getByText(/How it works/, { selector: 'summary' })).toBeInTheDocument()
+    expect(screen.getByText('First how-it-works paragraph.')).toBeInTheDocument()
+    expect(screen.getByText('Second how-it-works paragraph.')).toBeInTheDocument()
   })
 
   it('omits the toggle when the feature has no setting', () => {
@@ -80,5 +85,7 @@ describe('WhatsNewFeatureCard', () => {
     expect(screen.getByText('Demo feature')).toBeInTheDocument()
     expect(screen.queryByText('Enabled')).not.toBeInTheDocument()
     expect(screen.getByRole('link', { name: /Read more/ })).toBeInTheDocument()
+    // details render in read-only mode too (they're not gated on the toggle)
+    expect(screen.getByText('First how-it-works paragraph.')).toBeInTheDocument()
   })
 })

--- a/src/__tests__/components/WhatsNewTeaser.test.tsx
+++ b/src/__tests__/components/WhatsNewTeaser.test.tsx
@@ -1,0 +1,23 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vite-plus/test'
+
+vi.mock('next/link', () => ({
+  default: ({ children, href, ...p }: any) => (
+    <a href={href} {...p}>
+      {children}
+    </a>
+  ),
+}))
+
+import WhatsNewTeaser from '@/components/Dashboard/WhatsNewTeaser'
+import { whatsNew } from '@/lib/whatsNew'
+
+describe('WhatsNewTeaser', () => {
+  it("links to the What's New page and shows the newest feature title", () => {
+    render(<WhatsNewTeaser />)
+
+    expect(screen.getByText(/What's new in Dotabod/i)).toBeInTheDocument()
+    expect(screen.getByText(new RegExp(whatsNew[0].title))).toBeInTheDocument()
+    expect(screen.getByRole('link')).toHaveAttribute('href', '/dashboard/whats-new')
+  })
+})

--- a/src/__tests__/components/WhatsNewTeaser.test.tsx
+++ b/src/__tests__/components/WhatsNewTeaser.test.tsx
@@ -10,14 +10,15 @@ vi.mock('next/link', () => ({
 }))
 
 import WhatsNewTeaser from '@/components/Dashboard/WhatsNewTeaser'
-import { whatsNew } from '@/lib/whatsNew'
+import { whatsNewSorted } from '@/lib/whatsNew'
 
 describe('WhatsNewTeaser', () => {
   it("links to the What's New page and shows the newest feature title", () => {
     render(<WhatsNewTeaser />)
 
     expect(screen.getByText(/What's new in Dotabod/i)).toBeInTheDocument()
-    expect(screen.getByText(new RegExp(whatsNew[0].title))).toBeInTheDocument()
+    // assert the entry the teaser actually renders (newest by date), not source-array order
+    expect(screen.getByText(new RegExp(whatsNewSorted[0].title))).toBeInTheDocument()
     expect(screen.getByRole('link')).toHaveAttribute('href', '/dashboard/whats-new')
   })
 })

--- a/src/__tests__/lib/whatsNew.test.ts
+++ b/src/__tests__/lib/whatsNew.test.ts
@@ -15,6 +15,10 @@ describe('whatsNew registry', () => {
       if (e.tier) expect(['FREE', 'PRO']).toContain(e.tier)
       // A tri-state toggle must declare which setting it controls.
       if (e.followsNewFeatureMaster) expect(e.settingKey).toBeTruthy()
+      // Release dates are real and not in the future (catches typos like a wrong year).
+      expect(new Date(e.releaseDate).getTime()).toBeLessThanOrEqual(Date.now() + 86_400_000)
+      // Every entry must give the reader somewhere to go / something to see.
+      expect(Boolean(e.demo || e.deepLink || e.blogSlug || e.command || e.settingKey)).toBe(true)
     }
   })
 

--- a/src/__tests__/lib/whatsNew.test.ts
+++ b/src/__tests__/lib/whatsNew.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vite-plus/test'
+import { entryToggleChecked, type WhatsNewEntry, whatsNew } from '@/lib/whatsNew'
+
+const CATEGORIES = ['chat', 'overlay', 'commands', 'pages', 'advanced', 'bets', 'mmr', 'stream']
+
+describe('whatsNew registry', () => {
+  it('every entry has the required fields and a valid shape', () => {
+    for (const e of whatsNew) {
+      expect(e.id).toBeTruthy()
+      expect(e.title).toBeTruthy()
+      expect(e.description).toBeTruthy()
+      expect(e.releaseDate).toMatch(/^\d{4}-\d{2}-\d{2}$/)
+      expect(Number.isNaN(new Date(e.releaseDate).getTime())).toBe(false)
+      expect(CATEGORIES).toContain(e.category)
+      if (e.tier) expect(['FREE', 'PRO']).toContain(e.tier)
+      // A tri-state toggle must declare which setting it controls.
+      if (e.followsNewFeatureMaster) expect(e.settingKey).toBeTruthy()
+    }
+  })
+
+  it('has unique ids', () => {
+    const ids = whatsNew.map((e) => e.id)
+    expect(new Set(ids).size).toBe(ids.length)
+  })
+})
+
+describe('entryToggleChecked', () => {
+  const tri = { followsNewFeatureMaster: true } as WhatsNewEntry
+  const plain = {} as WhatsNewEntry
+
+  it('tri-state follows the master toggle when the value is unset', () => {
+    expect(entryToggleChecked(tri, null, true)).toBe(true)
+    expect(entryToggleChecked(tri, null, false)).toBe(false)
+    expect(entryToggleChecked(tri, undefined, true)).toBe(true)
+  })
+
+  it('tri-state explicit choice wins over the master', () => {
+    expect(entryToggleChecked(tri, false, true)).toBe(false)
+    expect(entryToggleChecked(tri, true, false)).toBe(true)
+  })
+
+  it('non-tri-state uses its own value', () => {
+    expect(entryToggleChecked(plain, true, false)).toBe(true)
+    expect(entryToggleChecked(plain, null, true)).toBe(false)
+  })
+})

--- a/src/__tests__/lib/whatsNew.test.ts
+++ b/src/__tests__/lib/whatsNew.test.ts
@@ -19,6 +19,11 @@ describe('whatsNew registry', () => {
       expect(new Date(e.releaseDate).getTime()).toBeLessThanOrEqual(Date.now() + 86_400_000)
       // Every entry must give the reader somewhere to go / something to see.
       expect(Boolean(e.demo || e.deepLink || e.blogSlug || e.command || e.settingKey)).toBe(true)
+      // `details` (the "how it works" expander) must be non-empty paragraphs when present.
+      if (e.details) {
+        expect(e.details.length).toBeGreaterThan(0)
+        for (const paragraph of e.details) expect(paragraph.trim().length).toBeGreaterThan(0)
+      }
     }
   })
 

--- a/src/__tests__/lib/whatsNew.test.ts
+++ b/src/__tests__/lib/whatsNew.test.ts
@@ -18,7 +18,9 @@ describe('whatsNew registry', () => {
       // Release dates are real and not in the future (catches typos like a wrong year).
       expect(new Date(e.releaseDate).getTime()).toBeLessThanOrEqual(Date.now() + 86_400_000)
       // Every entry must give the reader somewhere to go / something to see.
-      expect(Boolean(e.demo || e.deepLink || e.blogSlug || e.command || e.settingKey)).toBe(true)
+      expect(
+        Boolean(e.demo || e.demoCommand || e.deepLink || e.blogSlug || e.command || e.settingKey),
+      ).toBe(true)
       // `details` (the "how it works" expander) must be non-empty paragraphs when present.
       if (e.details) {
         expect(e.details.length).toBeGreaterThan(0)

--- a/src/__tests__/lib/whatsNew.test.ts
+++ b/src/__tests__/lib/whatsNew.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vite-plus/test'
-import { entryToggleChecked, type WhatsNewEntry, whatsNew } from '@/lib/whatsNew'
+import { deepLinkLabel, entryToggleChecked, type WhatsNewEntry, whatsNew } from '@/lib/whatsNew'
 
 const CATEGORIES = ['chat', 'overlay', 'commands', 'pages', 'advanced', 'bets', 'mmr', 'stream']
 
@@ -51,5 +51,33 @@ describe('entryToggleChecked', () => {
   it('non-tri-state uses its own value', () => {
     expect(entryToggleChecked(plain, true, false)).toBe(true)
     expect(entryToggleChecked(plain, null, true)).toBe(false)
+  })
+})
+
+const KNOWN_DEEP_LINK_PATHS = [
+  '/dashboard',
+  '/dashboard/billing',
+  '/dashboard/commands',
+  '/dashboard/features/overlay',
+  '/dashboard/help',
+]
+
+describe('deepLinkLabel', () => {
+  it('names each known destination', () => {
+    expect(deepLinkLabel({ path: '/dashboard' })).toBe('Open dashboard')
+    expect(deepLinkLabel({ path: '/dashboard/billing' })).toBe('Open billing')
+    expect(deepLinkLabel({ path: '/dashboard/commands' })).toBe('Open commands')
+    expect(deepLinkLabel({ path: '/dashboard/features/overlay' })).toBe('Open overlay settings')
+    expect(deepLinkLabel({ path: '/dashboard/help' })).toBe('Open help center')
+  })
+
+  it('humanizes the last path segment for an unknown destination', () => {
+    expect(deepLinkLabel({ path: '/dashboard/something' })).toBe('Open something')
+  })
+
+  it('every real deep-link points at a known, explicitly-labeled destination', () => {
+    for (const e of whatsNew) {
+      if (e.deepLink) expect(KNOWN_DEEP_LINK_PATHS).toContain(e.deepLink.path)
+    }
   })
 })

--- a/src/__tests__/lib/whatsNew.test.ts
+++ b/src/__tests__/lib/whatsNew.test.ts
@@ -23,6 +23,8 @@ describe('whatsNew registry', () => {
       if (e.details) {
         expect(e.details.length).toBeGreaterThan(0)
         for (const paragraph of e.details) expect(paragraph.trim().length).toBeGreaterThan(0)
+        // paragraphs must be unique (catches copy-paste; keeps the card's per-paragraph keys stable)
+        expect(new Set(e.details).size).toBe(e.details.length)
       }
     }
   })

--- a/src/__tests__/pages/api/notifications.test.ts
+++ b/src/__tests__/pages/api/notifications.test.ts
@@ -1,0 +1,147 @@
+import type { NextApiHandler } from 'next'
+import { createMocks } from 'node-mocks-http'
+import { beforeEach, describe, expect, it, vi } from 'vite-plus/test'
+
+vi.mock('@/lib/auth', () => ({ authOptions: {} }))
+vi.mock('@/lib/db', () => ({
+  default: {
+    notification: { findMany: vi.fn(), findFirst: vi.fn(), update: vi.fn() },
+    subscription: { findMany: vi.fn() },
+  },
+}))
+vi.mock('@/lib/api-middlewares/with-methods', () => ({
+  withMethods: (_methods: string[], handler: NextApiHandler) => handler,
+}))
+vi.mock('@/lib/api/getServerSession', () => ({ getServerSession: vi.fn() }))
+
+import { getServerSession } from '@/lib/api/getServerSession'
+import prisma from '@/lib/db'
+import handler from '@/pages/api/notifications'
+
+const auth = (userId: string | null) =>
+  vi.mocked(getServerSession).mockResolvedValue(userId ? ({ user: { id: userId } } as any) : null)
+
+describe('notifications API', () => {
+  beforeEach(() => {
+    vi.mocked(prisma.subscription.findMany).mockResolvedValue([] as any)
+    vi.mocked(prisma.notification.findMany).mockResolvedValue([] as any)
+  })
+
+  it('GET 401 when unauthenticated', async () => {
+    auth(null)
+    const { req, res } = createMocks({ method: 'GET' })
+    await handler(req, res)
+    expect(res.statusCode).toBe(401)
+  })
+
+  it('GET maps gift + new_feature rows and drops orphaned gifts', async () => {
+    auth('u1')
+    vi.mocked(prisma.notification.findMany).mockResolvedValue([
+      {
+        id: 'g1',
+        type: 'GIFT_SUBSCRIPTION',
+        isRead: false,
+        createdAt: new Date(),
+        userId: 'u1',
+        giftSubscription: {
+          giftType: 'monthly',
+          giftQuantity: 2,
+          giftMessage: 'hi',
+          senderName: 'Bob',
+        },
+      },
+      {
+        id: 'f1',
+        type: 'NEW_FEATURE',
+        isRead: false,
+        createdAt: new Date(),
+        userId: 'u1',
+        giftSubscription: null,
+      },
+      // orphaned gift (its giftSubscription row was deleted) → dropped
+      {
+        id: 'g2',
+        type: 'GIFT_SUBSCRIPTION',
+        isRead: false,
+        createdAt: new Date(),
+        userId: 'u1',
+        giftSubscription: null,
+      },
+    ] as any)
+
+    const { req, res } = createMocks({ method: 'GET', query: { includeRead: 'true' } })
+    await handler(req, res)
+
+    expect(res.statusCode).toBe(200)
+    const json = res._getJSONData()
+    expect(json.totalNotifications).toBe(2)
+    const byId = Object.fromEntries(json.notifications.map((n: any) => [n.id, n]))
+    expect(byId.g1).toMatchObject({
+      type: 'GIFT_SUBSCRIPTION',
+      senderName: 'Bob',
+      giftType: 'monthly',
+      giftQuantity: 2,
+    })
+    expect(byId.f1).toMatchObject({ type: 'NEW_FEATURE' })
+    expect(byId.f1.senderName).toBeUndefined()
+    expect(byId.g2).toBeUndefined()
+    expect(json.hasLifetime).toBe(false)
+  })
+
+  it('GET reports hasLifetime from active subscriptions', async () => {
+    auth('u1')
+    vi.mocked(prisma.subscription.findMany).mockResolvedValue([
+      { giftDetails: { giftType: 'lifetime' }, tier: 'PRO', transactionType: 'LIFETIME' },
+    ] as any)
+    const { req, res } = createMocks({ method: 'GET' })
+    await handler(req, res)
+    expect(res._getJSONData().hasLifetime).toBe(true)
+  })
+
+  it('GET defaults to unread-only unless includeRead=true', async () => {
+    auth('u1')
+    const { req, res } = createMocks({ method: 'GET' })
+    await handler(req, res)
+    expect(prisma.notification.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: expect.objectContaining({ isRead: false, userId: 'u1' }) }),
+    )
+  })
+
+  it('POST marks a notification read', async () => {
+    auth('u1')
+    vi.mocked(prisma.notification.findFirst).mockResolvedValue({ id: 'n1', userId: 'u1' } as any)
+    vi.mocked(prisma.notification.update).mockResolvedValue({ id: 'n1' } as any)
+    const { req, res } = createMocks({ method: 'POST', body: { notificationId: 'n1' } })
+    await handler(req, res)
+    expect(res.statusCode).toBe(200)
+    expect(prisma.notification.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: { isRead: true, updatedAt: expect.any(Date) },
+        where: { id: 'n1' },
+      }),
+    )
+  })
+
+  it("POST 404 when the notification isn't the caller's", async () => {
+    auth('u1')
+    vi.mocked(prisma.notification.findFirst).mockResolvedValue(null as any)
+    const { req, res } = createMocks({ method: 'POST', body: { notificationId: 'n1' } })
+    await handler(req, res)
+    expect(res.statusCode).toBe(404)
+    expect(prisma.notification.update).not.toHaveBeenCalled()
+  })
+
+  it('POST 400 on an invalid body', async () => {
+    auth('u1')
+    const { req, res } = createMocks({ method: 'POST', body: {} })
+    await handler(req, res)
+    expect(res.statusCode).toBe(400)
+  })
+
+  it('405 on an unsupported method', async () => {
+    auth('u1')
+    const { req, res } = createMocks({ method: 'PUT' })
+    await handler(req, res)
+    expect(res.statusCode).toBe(405)
+  })
+})

--- a/src/components/Dashboard/CommandDetail.tsx
+++ b/src/components/Dashboard/CommandDetail.tsx
@@ -691,6 +691,22 @@ const CommandDetail: Record<
     ),
     title: 'Roshan and aegis',
   },
+  commandSet: {
+    alias: ['cosmetics', 'loadout'],
+    allowed: 'all',
+    cmd: '!set',
+    description:
+      "Shows your current hero's equipped cosmetics with a link to your public collection page. Loadouts are captured automatically as you pick heroes on stream.",
+    key: 'commandSet',
+    response: (props) => (
+      <TwitchChat
+        {...props}
+        command='!set'
+        response='Pudge has 5 equipped cosmetics → dotabod.com/<streamername>/set'
+      />
+    ),
+    title: 'Cosmetic set',
+  },
   commandSetdelay: {
     alias: ['delay=', 'setstreamdelay', 'streamdelay='],
     allowed: 'mods',

--- a/src/components/Dashboard/DashboardShell.tsx
+++ b/src/components/Dashboard/DashboardShell.tsx
@@ -226,10 +226,11 @@ export default function DashboardShell({
   // Update notification state when data changes
   useEffect(() => {
     // This toast is gift-specific; the notifications endpoint now returns other types
-    // too (e.g. new-feature), so pick the first unread GIFT_SUBSCRIPTION only.
-    const giftNotification = (giftNotificationData?.notifications || []).find(
+    // too (e.g. new-feature), so consider only unread GIFT_SUBSCRIPTION rows.
+    const unreadGifts = (giftNotificationData?.notifications || []).filter(
       (n) => n?.type === 'GIFT_SUBSCRIPTION' && !n?.read,
     )
+    const giftNotification = unreadGifts[0]
     if (giftNotification) {
       setGiftDetails({
         giftMessage: giftNotification.giftMessage,
@@ -245,7 +246,8 @@ export default function DashboardShell({
     }
 
     setHasLifetime(giftNotificationData?.hasLifetime || false)
-    setTotalNotifications(giftNotificationData?.totalNotifications || 0)
+    // Gift-only count for the toast copy; the endpoint's totalNotifications mixes types.
+    setTotalNotifications(unreadGifts.length)
   }, [giftNotificationData])
 
   const dismissGiftNotification = async () => {

--- a/src/components/Dashboard/DashboardShell.tsx
+++ b/src/components/Dashboard/DashboardShell.tsx
@@ -205,9 +205,9 @@ export default function DashboardShell({
     }
   }, [router.pathname, router.asPath])
 
-  // Fetch gift notifications from the API
+  // Fetch notifications from the API (gift toast filters to gift type below)
   const { data: giftNotificationData, mutate: refreshGiftNotifications } = useSWR(
-    status === 'authenticated' ? '/api/gift-notifications' : null,
+    status === 'authenticated' ? '/api/notifications' : null,
     fetcher,
     STABLE_SWR_OPTIONS,
   )
@@ -225,31 +225,34 @@ export default function DashboardShell({
 
   // Update notification state when data changes
   useEffect(() => {
-    if (giftNotificationData?.hasNotification && giftNotificationData.notifications?.length > 0) {
-      // Get the first unread notification
-      const firstNotification = giftNotificationData.notifications[0]
+    // This toast is gift-specific; the notifications endpoint now returns other types
+    // too (e.g. new-feature), so pick the first unread GIFT_SUBSCRIPTION only.
+    const giftNotification = (giftNotificationData?.notifications || []).find(
+      (n) => n?.type === 'GIFT_SUBSCRIPTION' && !n?.read,
+    )
+    if (giftNotification) {
       setGiftDetails({
-        giftMessage: firstNotification.giftMessage,
-        giftQuantity: firstNotification.giftQuantity || 1,
-        giftType: firstNotification.giftType,
-        id: firstNotification.id,
-        senderName: firstNotification.senderName,
+        giftMessage: giftNotification.giftMessage,
+        giftQuantity: giftNotification.giftQuantity || 1,
+        giftType: giftNotification.giftType,
+        id: giftNotification.id,
+        senderName: giftNotification.senderName,
       })
       setHasGiftNotification(true)
-
-      setHasLifetime(giftNotificationData.hasLifetime || false)
-      setTotalNotifications(giftNotificationData.totalNotifications || 0)
     } else {
       setHasGiftNotification(false)
       setGiftDetails(null)
     }
+
+    setHasLifetime(giftNotificationData?.hasLifetime || false)
+    setTotalNotifications(giftNotificationData?.totalNotifications || 0)
   }, [giftNotificationData])
 
   const dismissGiftNotification = async () => {
     if (giftDetails?.id) {
       try {
         // Call API to mark notification as read
-        const response = await fetch('/api/gift-notifications', {
+        const response = await fetch('/api/notifications', {
           body: JSON.stringify({
             notificationId: giftDetails.id,
           }),

--- a/src/components/Dashboard/Features/NewFeaturesCard.tsx
+++ b/src/components/Dashboard/Features/NewFeaturesCard.tsx
@@ -22,7 +22,7 @@ export default function NewFeaturesCard() {
           href='/dashboard/whats-new'
           className='text-sm font-medium text-purple-400 hover:text-purple-300'
         >
-          See what&apos;s new →
+          See what&apos;s new
         </Link>
       </div>
     </Card>

--- a/src/components/Dashboard/Features/NewFeaturesCard.tsx
+++ b/src/components/Dashboard/Features/NewFeaturesCard.tsx
@@ -1,0 +1,30 @@
+import Link from 'next/link'
+import { Settings } from '@/lib/defaultSettings'
+import { Card } from '@/ui/card'
+import { TierSwitch } from './TierSwitch'
+
+// Account-wide control for how new dotabod features (across chat, overlays, betting, etc.)
+// roll out — deliberately NOT a feature-specific toggle. The master sets the default for
+// features a streamer hasn't touched; each feature's own toggle lives on the What's New page.
+export default function NewFeaturesCard() {
+  return (
+    <Card title='New features'>
+      <div className='mb-4'>
+        Dotabod ships new features across chat, overlays, and more over time. Leave this on to get
+        them automatically as they launch, or turn it off to opt in to each one yourself.
+      </div>
+      <div className='ml-1 flex flex-col space-y-3'>
+        <TierSwitch
+          settingKey={Settings.autoOptInNewFeatures}
+          label='Automatically enable new features as they launch'
+        />
+        <Link
+          href='/dashboard/whats-new'
+          className='text-sm font-medium text-purple-400 hover:text-purple-300'
+        >
+          See what&apos;s new →
+        </Link>
+      </div>
+    </Card>
+  )
+}

--- a/src/components/Dashboard/Features/WhatsNewFeatureCard.tsx
+++ b/src/components/Dashboard/Features/WhatsNewFeatureCard.tsx
@@ -61,7 +61,7 @@ export default function WhatsNewFeatureCard({
                 rel='noreferrer'
                 className='mt-2 inline-block text-xs font-medium text-purple-400 hover:text-purple-300'
               >
-                {entry.demo.exampleLabel ?? 'See a live example →'}
+                {entry.demo.exampleLabel ?? 'See a live example'}
               </a>
             )}
           </div>
@@ -96,7 +96,7 @@ export default function WhatsNewFeatureCard({
                 href={`${entry.deepLink.path}${entry.deepLink.section ? `#${entry.deepLink.section}` : ''}`}
                 className='text-sm font-medium text-purple-400 hover:text-purple-300'
               >
-                {deepLinkLabel(entry.deepLink)} →
+                {deepLinkLabel(entry.deepLink)}
               </Link>
             )}
             {entry.blogSlug && (
@@ -104,7 +104,7 @@ export default function WhatsNewFeatureCard({
                 href={`/blog/${entry.blogSlug}`}
                 className='text-sm font-medium text-purple-400 hover:text-purple-300'
               >
-                Read more →
+                Read more
               </Link>
             )}
             {entry.docsUrl && (
@@ -114,7 +114,7 @@ export default function WhatsNewFeatureCard({
                 rel='noreferrer'
                 className='text-sm font-medium text-purple-400 hover:text-purple-300'
               >
-                Read more →
+                Read more
               </a>
             )}
           </div>

--- a/src/components/Dashboard/Features/WhatsNewFeatureCard.tsx
+++ b/src/components/Dashboard/Features/WhatsNewFeatureCard.tsx
@@ -48,6 +48,25 @@ export default function WhatsNewFeatureCard({
 
         <p className='text-sm text-gray-300'>{entry.description}</p>
 
+        {entry.demo && (
+          <div className='rounded-md border border-gray-700/60 bg-gray-800/50 p-3'>
+            <div className='mb-1.5 text-xs font-medium text-gray-500'>Example</div>
+            {entry.demo.chat && (
+              <p className='font-mono text-xs text-gray-300'>{entry.demo.chat}</p>
+            )}
+            {entry.demo.exampleUrl && (
+              <a
+                href={entry.demo.exampleUrl}
+                target='_blank'
+                rel='noreferrer'
+                className='mt-2 inline-block text-xs font-medium text-purple-400 hover:text-purple-300'
+              >
+                {entry.demo.exampleLabel ?? 'See a live example →'}
+              </a>
+            )}
+          </div>
+        )}
+
         {hasFooter && (
           <div className='flex flex-wrap items-center gap-4 border-t border-gray-700 pt-3'>
             {!readOnly && entry.settingKey && (

--- a/src/components/Dashboard/Features/WhatsNewFeatureCard.tsx
+++ b/src/components/Dashboard/Features/WhatsNewFeatureCard.tsx
@@ -1,6 +1,6 @@
 import Link from 'next/link'
 import { useUpdateSetting } from '@/lib/hooks/useUpdateSetting'
-import { entryToggleChecked, type WhatsNewEntry } from '@/lib/whatsNew'
+import { deepLinkLabel, entryToggleChecked, type WhatsNewEntry } from '@/lib/whatsNew'
 import { Card } from '@/ui/card'
 import { formatDate } from '@/utils/formatDate'
 import { TierSwitch } from './TierSwitch'
@@ -96,7 +96,7 @@ export default function WhatsNewFeatureCard({
                 href={`${entry.deepLink.path}${entry.deepLink.section ? `#${entry.deepLink.section}` : ''}`}
                 className='text-sm font-medium text-purple-400 hover:text-purple-300'
               >
-                Open settings →
+                {deepLinkLabel(entry.deepLink)} →
               </Link>
             )}
             {entry.blogSlug && (

--- a/src/components/Dashboard/Features/WhatsNewFeatureCard.tsx
+++ b/src/components/Dashboard/Features/WhatsNewFeatureCard.tsx
@@ -48,7 +48,7 @@ export default function WhatsNewFeatureCard({
 
         <p className='text-sm text-gray-300'>{entry.description}</p>
 
-        {entry.demo && (
+        {entry.demo && (entry.demo.chat || entry.demo.exampleUrl) && (
           <div className='rounded-md border border-gray-700/60 bg-gray-800/50 p-3'>
             <div className='mb-1.5 text-xs font-medium text-gray-500'>Example</div>
             {entry.demo.chat && (
@@ -70,12 +70,17 @@ export default function WhatsNewFeatureCard({
         {entry.details && entry.details.length > 0 && (
           <details className='group rounded-md border border-gray-700/60 bg-gray-800/30 px-3 py-2'>
             <summary className='flex cursor-pointer list-none select-none items-center gap-1 text-xs font-medium text-purple-400 hover:text-purple-300 [&::-webkit-details-marker]:hidden'>
-              <span className='inline-block transition-transform group-open:rotate-90'>›</span>
+              <span
+                aria-hidden='true'
+                className='inline-block transition-transform group-open:rotate-90'
+              >
+                ›
+              </span>
               How it works
             </summary>
             <div className='mt-2 space-y-2 text-sm text-gray-300'>
-              {entry.details.map((paragraph) => (
-                <p key={paragraph}>{paragraph}</p>
+              {entry.details.map((paragraph, i) => (
+                <p key={`${entry.id}-${i}`}>{paragraph}</p>
               ))}
             </div>
           </details>

--- a/src/components/Dashboard/Features/WhatsNewFeatureCard.tsx
+++ b/src/components/Dashboard/Features/WhatsNewFeatureCard.tsx
@@ -67,6 +67,20 @@ export default function WhatsNewFeatureCard({
           </div>
         )}
 
+        {entry.details && entry.details.length > 0 && (
+          <details className='group rounded-md border border-gray-700/60 bg-gray-800/30 px-3 py-2'>
+            <summary className='flex cursor-pointer list-none select-none items-center gap-1 text-xs font-medium text-purple-400 hover:text-purple-300 [&::-webkit-details-marker]:hidden'>
+              <span className='inline-block transition-transform group-open:rotate-90'>›</span>
+              How it works
+            </summary>
+            <div className='mt-2 space-y-2 text-sm text-gray-300'>
+              {entry.details.map((paragraph) => (
+                <p key={paragraph}>{paragraph}</p>
+              ))}
+            </div>
+          </details>
+        )}
+
         {hasFooter && (
           <div className='flex flex-wrap items-center gap-4 border-t border-gray-700 pt-3'>
             {!readOnly && entry.settingKey && (

--- a/src/components/Dashboard/Features/WhatsNewFeatureCard.tsx
+++ b/src/components/Dashboard/Features/WhatsNewFeatureCard.tsx
@@ -1,4 +1,5 @@
 import Link from 'next/link'
+import CommandDetail from '@/components/Dashboard/CommandDetail'
 import { useUpdateSetting } from '@/lib/hooks/useUpdateSetting'
 import { deepLinkLabel, entryToggleChecked, type WhatsNewEntry } from '@/lib/whatsNew'
 import { Card } from '@/ui/card'
@@ -48,13 +49,18 @@ export default function WhatsNewFeatureCard({
 
         <p className='text-sm text-gray-300'>{entry.description}</p>
 
-        {entry.demo && (entry.demo.chat || entry.demo.exampleUrl) && (
+        {(entry.demoCommand || entry.demo?.chat || entry.demo?.exampleUrl) && (
           <div className='rounded-md border border-gray-700/60 bg-gray-800/50 p-3'>
             <div className='mb-1.5 text-xs font-medium text-gray-500'>Example</div>
-            {entry.demo.chat && (
+            {entry.demoCommand ? (
+              // Reuse the real command's <TwitchChat> sample so flags, emotes, and emoji
+              // images render exactly as on the commands page. `all=false` keeps it to the
+              // single headline line (no extra "!np add"/usage examples).
+              CommandDetail[entry.demoCommand].response(null, false)
+            ) : entry.demo?.chat ? (
               <p className='font-mono text-xs text-gray-300'>{entry.demo.chat}</p>
-            )}
-            {entry.demo.exampleUrl && (
+            ) : null}
+            {entry.demo?.exampleUrl && (
               <a
                 href={entry.demo.exampleUrl}
                 target='_blank'

--- a/src/components/Dashboard/Features/WhatsNewFeatureCard.tsx
+++ b/src/components/Dashboard/Features/WhatsNewFeatureCard.tsx
@@ -1,0 +1,92 @@
+import Link from 'next/link'
+import { useUpdateSetting } from '@/lib/hooks/useUpdateSetting'
+import { entryToggleChecked, type WhatsNewEntry } from '@/lib/whatsNew'
+import { Card } from '@/ui/card'
+import { formatDate } from '@/utils/formatDate'
+import { TierSwitch } from './TierSwitch'
+
+// One feature on the What's New page: title, release date, description, an inline toggle (when
+// the feature has a setting), and deep-link / read-more links.
+export default function WhatsNewFeatureCard({
+  entry,
+  master,
+  latest,
+  readOnly,
+}: {
+  entry: WhatsNewEntry
+  master?: boolean
+  latest?: boolean
+  readOnly?: boolean
+}) {
+  // Always call the hook (rules of hooks); it no-ops when there's no settingKey.
+  const { data: value, updateSetting } = useUpdateSetting<boolean | null>(entry.settingKey)
+  const checked = entryToggleChecked(entry, value, master)
+
+  // The public changelog (/whats-new) renders the same cards read-only — no toggle.
+  const hasFooter =
+    (!readOnly && Boolean(entry.settingKey)) ||
+    Boolean(entry.deepLink) ||
+    Boolean(entry.blogSlug) ||
+    Boolean(entry.docsUrl)
+
+  return (
+    <Card title={entry.title}>
+      <div className='space-y-3'>
+        <div className='flex flex-wrap items-center gap-2 text-xs text-gray-400'>
+          <span>{formatDate(entry.releaseDate)}</span>
+          {latest && (
+            <span className='rounded bg-purple-600 px-1.5 py-0.5 font-medium text-white'>
+              Latest
+            </span>
+          )}
+          {entry.command && (
+            <span className='rounded bg-gray-700 px-1.5 py-0.5 font-mono text-gray-200'>
+              {entry.command}
+            </span>
+          )}
+        </div>
+
+        <p className='text-sm text-gray-300'>{entry.description}</p>
+
+        {hasFooter && (
+          <div className='flex flex-wrap items-center gap-4 border-t border-gray-700 pt-3'>
+            {!readOnly && entry.settingKey && (
+              <TierSwitch
+                settingKey={entry.settingKey}
+                checked={checked}
+                onChange={(c) => updateSetting(c)}
+                label='Enabled'
+              />
+            )}
+            {entry.deepLink && (
+              <Link
+                href={`${entry.deepLink.path}${entry.deepLink.section ? `#${entry.deepLink.section}` : ''}`}
+                className='text-sm font-medium text-purple-400 hover:text-purple-300'
+              >
+                Open settings →
+              </Link>
+            )}
+            {entry.blogSlug && (
+              <Link
+                href={`/blog/${entry.blogSlug}`}
+                className='text-sm font-medium text-purple-400 hover:text-purple-300'
+              >
+                Read more →
+              </Link>
+            )}
+            {entry.docsUrl && (
+              <a
+                href={entry.docsUrl}
+                target='_blank'
+                rel='noreferrer'
+                className='text-sm font-medium text-purple-400 hover:text-purple-300'
+              >
+                Read more →
+              </a>
+            )}
+          </div>
+        )}
+      </div>
+    </Card>
+  )
+}

--- a/src/components/Dashboard/WhatsNewTeaser.tsx
+++ b/src/components/Dashboard/WhatsNewTeaser.tsx
@@ -20,7 +20,7 @@ export default function WhatsNewTeaser() {
           <div className='text-sm text-gray-400'>{latest.map((e) => e.title).join(' · ')}</div>
         </div>
       </div>
-      <span className='shrink-0 text-sm font-medium text-purple-400'>See all →</span>
+      <span className='shrink-0 text-sm font-medium text-purple-400'>See all</span>
     </Link>
   )
 }

--- a/src/components/Dashboard/WhatsNewTeaser.tsx
+++ b/src/components/Dashboard/WhatsNewTeaser.tsx
@@ -1,0 +1,28 @@
+import { Sparkles } from 'lucide-react'
+import Link from 'next/link'
+import { whatsNew } from '@/lib/whatsNew'
+
+// Compact, unmissable pointer to the What's New page (the bell gets ignored). Shows the
+// titles of the newest entries and links to the full list.
+export default function WhatsNewTeaser() {
+  const latest = [...whatsNew]
+    .sort((a, b) => new Date(b.releaseDate).getTime() - new Date(a.releaseDate).getTime())
+    .slice(0, 2)
+  if (!latest.length) return null
+
+  return (
+    <Link
+      href='/dashboard/whats-new'
+      className='mb-6 flex items-center justify-between gap-4 rounded-lg border border-purple-500/30 bg-purple-500/5 p-4 transition-colors hover:border-purple-500/60'
+    >
+      <div className='flex items-start gap-3'>
+        <Sparkles className='mt-0.5 h-5 w-5 shrink-0 text-purple-400' />
+        <div>
+          <div className='font-semibold text-white'>What&apos;s new in Dotabod</div>
+          <div className='text-sm text-gray-400'>{latest.map((e) => e.title).join(' · ')}</div>
+        </div>
+      </div>
+      <span className='shrink-0 text-sm font-medium text-purple-400'>See all →</span>
+    </Link>
+  )
+}

--- a/src/components/Dashboard/WhatsNewTeaser.tsx
+++ b/src/components/Dashboard/WhatsNewTeaser.tsx
@@ -1,13 +1,11 @@
 import { Sparkles } from 'lucide-react'
 import Link from 'next/link'
-import { whatsNew } from '@/lib/whatsNew'
+import { whatsNewSorted } from '@/lib/whatsNew'
 
 // Compact, unmissable pointer to the What's New page (the bell gets ignored). Shows the
 // titles of the newest entries and links to the full list.
 export default function WhatsNewTeaser() {
-  const latest = [...whatsNew]
-    .sort((a, b) => new Date(b.releaseDate).getTime() - new Date(a.releaseDate).getTime())
-    .slice(0, 2)
+  const latest = whatsNewSorted.slice(0, 2)
   if (!latest.length) return null
 
   return (

--- a/src/components/Dashboard/navigation.tsx
+++ b/src/components/Dashboard/navigation.tsx
@@ -45,6 +45,10 @@ export const navigation = [
   {
     children: [
       {
+        href: '/dashboard/whats-new',
+        name: "What's New",
+      },
+      {
         href: '/dashboard/features',
         name: 'Overview',
       },

--- a/src/components/Homepage/Header.tsx
+++ b/src/components/Homepage/Header.tsx
@@ -72,6 +72,7 @@ export const Header: FC = () => (
                           <MobileNavLink href='/#faqs'>FAQs</MobileNavLink>
                           <MobileNavLink href='/contact'>Contact Us</MobileNavLink>
                           <MobileNavLink href='/blog'>Blog</MobileNavLink>
+                          <MobileNavLink href='/whats-new'>What&apos;s New</MobileNavLink>
                           <MobileNavLink href='/privacy-policy'>Privacy Policy</MobileNavLink>
                           <MobileNavLink href='/terms-of-service'>Terms of Service</MobileNavLink>
                           <MobileNavLink href='/cookies'>Cookie Policy</MobileNavLink>

--- a/src/components/NavLinks.tsx
+++ b/src/components/NavLinks.tsx
@@ -31,6 +31,7 @@ export const NavLinks: FC<NavLinksProps> = ({ bottom = false }) => {
     ['Streamers', '/streamers', 'Browse Dota 2 streamers live right now'],
     ['Pricing', '/#pricing'],
     ['Blog', '/blog'],
+    ["What's New", '/whats-new', 'Follow the latest Dotabod features and releases'],
     ['Gift Pro', '/gift', 'Gift Dotabod Pro to your favorite streamer'],
     ['Contact Us', '/contact'],
     ...additional,

--- a/src/components/UserAccountNav.tsx
+++ b/src/components/UserAccountNav.tsx
@@ -12,16 +12,23 @@ import useSWR from 'swr'
 import { fetcher } from '@/lib/fetcher'
 import { SETTINGS_SWR_OPTIONS, STABLE_SWR_OPTIONS } from '@/lib/hooks/useUpdateSetting'
 
-// Define the notification type
-interface GiftNotification {
+// Notifications shown in the dashboard bell, discriminated by `type`.
+interface BaseNotification {
   id: string
+  createdAt: string
+  read?: boolean
+}
+interface GiftNotification extends BaseNotification {
+  type?: 'GIFT_SUBSCRIPTION'
   senderName: string
   giftMessage?: string
   giftType: 'monthly' | 'annual' | 'lifetime'
   giftQuantity?: number
-  createdAt: string
-  read?: boolean
 }
+interface NewFeatureNotification extends BaseNotification {
+  type: 'NEW_FEATURE'
+}
+type AppNotification = GiftNotification | NewFeatureNotification
 
 interface UserButtonProps extends React.ComponentPropsWithoutRef<'button'> {
   user: Session['user']
@@ -45,7 +52,7 @@ const UserButton = ({ user, className }: UserButtonProps) => {
     data: giftNotificationData,
     error: notificationError,
     mutate: refreshGiftNotifications,
-  } = useSWR('/api/gift-notifications?includeRead=true', fetcher, {
+  } = useSWR('/api/notifications?includeRead=true', fetcher, {
     ...STABLE_SWR_OPTIONS,
     // Configuration to fetch only once on mount
     // Keep error handling
@@ -76,7 +83,7 @@ const UserButton = ({ user, className }: UserButtonProps) => {
     return () => clearTimeout(timer)
   }, [imageLoaded])
 
-  const notifications = (giftNotificationData?.notifications || []) as GiftNotification[]
+  const notifications = (giftNotificationData?.notifications || []) as AppNotification[]
   const totalUnreadNotifications = notifications.filter((n) => !n.read).length
 
   // Pagination state
@@ -117,7 +124,7 @@ const UserButton = ({ user, className }: UserButtonProps) => {
   // Handle notification dismissal
   const dismissNotification = async (notificationId: string) => {
     try {
-      await fetch('/api/gift-notifications', {
+      await fetch('/api/notifications', {
         body: JSON.stringify({
           notificationId,
         }),
@@ -215,37 +222,77 @@ const UserButton = ({ user, className }: UserButtonProps) => {
               <div className='max-h-80 overflow-y-auto'>
                 {sortedNotifications
                   .slice((currentPage - 1) * pageSize, currentPage * pageSize)
-                  .map((notification) => (
-                    <div
-                      key={notification.id}
-                      className={clsx(
-                        'relative rounded-lg p-4 mb-2',
-                        notification.read ? 'bg-gray-800/50' : 'bg-gray-800',
-                      )}
-                    >
-                      <div className='flex justify-between items-start'>
-                        <div className='font-semibold text-white'>Gift Subscription</div>
-                        <div className='text-xs text-gray-400'>
-                          {new Date(notification.createdAt).toLocaleDateString()}
-                        </div>
-                      </div>
-                      <p className='mt-1 text-gray-300'>
-                        {`${notification.senderName || 'Someone'} has gifted you ${formatGiftType(notification.giftType, notification.giftQuantity)}!`}
-                      </p>
-                      {notification.giftMessage && (
-                        <p className='mt-2 italic text-gray-400'>"{notification.giftMessage}"</p>
-                      )}
-                      {!notification.read && (
-                        <Button
-                          onClick={() => dismissNotification(notification.id)}
-                          className='mt-2'
-                          size='small'
+                  .map((notification) => {
+                    if (notification.type === 'NEW_FEATURE') {
+                      return (
+                        <div
+                          key={notification.id}
+                          className={clsx(
+                            'relative rounded-lg p-4 mb-2',
+                            notification.read ? 'bg-gray-800/50' : 'bg-gray-800',
+                          )}
                         >
-                          Dismiss
-                        </Button>
-                      )}
-                    </div>
-                  ))}
+                          <div className='flex justify-between items-start'>
+                            <div className='font-semibold text-white'>New features</div>
+                            <div className='text-xs text-gray-400'>
+                              {new Date(notification.createdAt).toLocaleDateString()}
+                            </div>
+                          </div>
+                          <p className='mt-1 text-gray-300'>
+                            Dotabod now turns on new features automatically. Don&apos;t want new
+                            stuff on by default? You can opt out anytime.
+                          </p>
+                          <div className='mt-2 flex gap-2'>
+                            <Link href='/dashboard/whats-new'>
+                              <Button type='primary' size='small'>
+                                See what&apos;s new
+                              </Button>
+                            </Link>
+                            {!notification.read && (
+                              <Button
+                                onClick={() => dismissNotification(notification.id)}
+                                size='small'
+                              >
+                                Dismiss
+                              </Button>
+                            )}
+                          </div>
+                        </div>
+                      )
+                    }
+
+                    return (
+                      <div
+                        key={notification.id}
+                        className={clsx(
+                          'relative rounded-lg p-4 mb-2',
+                          notification.read ? 'bg-gray-800/50' : 'bg-gray-800',
+                        )}
+                      >
+                        <div className='flex justify-between items-start'>
+                          <div className='font-semibold text-white'>Gift Subscription</div>
+                          <div className='text-xs text-gray-400'>
+                            {new Date(notification.createdAt).toLocaleDateString()}
+                          </div>
+                        </div>
+                        <p className='mt-1 text-gray-300'>
+                          {`${notification.senderName || 'Someone'} has gifted you ${formatGiftType(notification.giftType, notification.giftQuantity)}!`}
+                        </p>
+                        {notification.giftMessage && (
+                          <p className='mt-2 italic text-gray-400'>"{notification.giftMessage}"</p>
+                        )}
+                        {!notification.read && (
+                          <Button
+                            onClick={() => dismissNotification(notification.id)}
+                            className='mt-2'
+                            size='small'
+                          >
+                            Dismiss
+                          </Button>
+                        )}
+                      </div>
+                    )
+                  })}
 
                 {totalFilteredNotifications > pageSize && (
                   <div className='flex justify-between items-center mt-4'>

--- a/src/lib/defaultSettings.ts
+++ b/src/lib/defaultSettings.ts
@@ -40,6 +40,7 @@ export const commands = {
   commandRefresh: true,
   commandResetwl: true,
   commandRosh: true,
+  commandSet: true,
   commandSetdelay: true,
   commandSetmmr: true,
   commandShard: true,

--- a/src/lib/defaultSettings.ts
+++ b/src/lib/defaultSettings.ts
@@ -176,6 +176,13 @@ export const defaultSettings = {
     minimumRankTier: 0,
   },
   discardZeroBets: false,
+  // Master switch: when on (default), features released after a streamer's last
+  // visit are enabled by default. Per-feature toggles (e.g. cosmeticsAnnounce)
+  // override this once explicitly set.
+  autoOptInNewFeatures: true,
+  // New-feature toggle for cosmetic-set announcements. null = follow
+  // autoOptInNewFeatures; true/false = explicit streamer choice (always wins).
+  cosmeticsAnnounce: null as boolean | null,
   ...commands,
   autoCommandsOnMatchStart: [],
 }

--- a/src/lib/settingsMetadata.ts
+++ b/src/lib/settingsMetadata.ts
@@ -334,6 +334,24 @@ export const settingsMetadata: SettingMetadata[] = [
     searchTerms: ['roshan', 'killed', 'rosh', 'chat'],
   },
   {
+    category: 'advanced',
+    description:
+      'Automatically enable new dotabod features (chat, overlay, and more) as they launch',
+    key: 'autoOptInNewFeatures',
+    label: 'Auto-enable new features',
+    page: { path: '/dashboard/features', section: 'new-features' },
+    searchTerms: ['new', 'features', 'auto', 'opt in', 'updates', 'beta'],
+  },
+  {
+    category: 'chat',
+    description:
+      "Announce your hero's captured cosmetic set in chat with a link to your collection",
+    key: 'cosmeticsAnnounce',
+    label: 'Cosmetic Set Announcements',
+    page: { path: '/dashboard/whats-new', section: 'cosmetics' },
+    searchTerms: ['cosmetic', 'set', 'loadout', 'items', 'hero', 'chat', 'new features'],
+  },
+  {
     category: 'chat',
     description: 'Announce deaths with passive items unused',
     isNested: true,

--- a/src/lib/validations/setting.ts
+++ b/src/lib/validations/setting.ts
@@ -22,6 +22,9 @@ const settingsSchema = {
   }),
   chatter: z.boolean(),
   autoOptInNewFeatures: z.boolean(),
+  // Tri-state: the null "follow autoOptInNewFeatures" state is the ABSENCE of a settings row
+  // (the default), not a persisted value. The UI only ever PATCHes true/false, and Prisma Json
+  // columns can't store raw null, so the write schema is boolean.
   cosmeticsAnnounce: z.boolean(),
   chatters: z
     .object({

--- a/src/lib/validations/setting.ts
+++ b/src/lib/validations/setting.ts
@@ -21,6 +21,8 @@ const settingsSchema = {
     yes: z.string().max(25),
   }),
   chatter: z.boolean(),
+  autoOptInNewFeatures: z.boolean(),
+  cosmeticsAnnounce: z.boolean(),
   chatters: z
     .object({
       bounties: z.object({ enabled: z.boolean() }),

--- a/src/lib/whatsNew.ts
+++ b/src/lib/whatsNew.ts
@@ -39,6 +39,194 @@ export const whatsNew: WhatsNewEntry[] = [
       exampleLabel: "See arteezy's set page →",
     },
   },
+  {
+    id: 'cosmetic-set-pages',
+    title: 'Hero cosmetic set pages',
+    description:
+      "Browse any streamer's equipped cosmetics hero-by-hero — with rarity, a completion meter, and a trophy tally — on their public set page.",
+    releaseDate: '2026-06-02',
+    category: 'pages',
+    demo: {
+      exampleUrl: 'https://dotabod.com/arteezy/set',
+      exampleLabel: "Browse arteezy's collection →",
+    },
+  },
+  {
+    id: 'paypal',
+    title: 'PayPal for Dotabod Pro',
+    description:
+      'You can now subscribe to — or gift — Dotabod Pro with PayPal (monthly, annual, or lifetime), right alongside card and crypto.',
+    releaseDate: '2026-05-28',
+    category: 'advanced',
+    blogSlug: 'paypal-payments',
+    deepLink: { path: '/dashboard/billing' },
+  },
+  {
+    id: 'streamers-directory',
+    title: 'Streamers directory',
+    description:
+      'A public, searchable directory of Dotabod streamers you can filter by rank and sort by follower count.',
+    releaseDate: '2026-05-31',
+    category: 'pages',
+    demo: {
+      exampleUrl: 'https://dotabod.com/streamers',
+      exampleLabel: 'Browse the directory →',
+    },
+  },
+  {
+    id: 'gift-redesign',
+    title: 'Redesigned gifting',
+    description:
+      'Gifting Pro got a cleaner flow: a live chat preview, preset durations, and a running price summary before checkout.',
+    releaseDate: '2026-05-30',
+    category: 'pages',
+    demo: {
+      exampleUrl: 'https://dotabod.com/arteezy/gift',
+      exampleLabel: "See arteezy's gift page →",
+    },
+  },
+  {
+    id: 'command-suggestions',
+    title: 'Inline command tips',
+    description:
+      'Dotabod can append a related command hint to its first reply, so your chat discovers more of what it can do.',
+    releaseDate: '2026-05-25',
+    category: 'chat',
+    deepLink: { path: '/dashboard/commands' },
+  },
+  {
+    id: 'streamers-command',
+    title: '!streamers',
+    description:
+      'Anonymously tells chat how many other Dotabod streamers are in your current match. No names are shown to avoid cross-chat drama.',
+    releaseDate: '2026-05-22',
+    category: 'commands',
+    command: '!streamers',
+    settingKey: 'commandStreamers',
+    deepLink: { path: '/dashboard/commands' },
+    demo: { chat: 'Playing with 2 other Dotabod streamers Okayge' },
+  },
+  {
+    id: 'mod-resolution',
+    title: 'Easier bet resolution',
+    description:
+      '!unresolved now lists pending matches with KDA, length, and match IDs, and a bare !won or !lost flips your most recent match — no match ID needed.',
+    releaseDate: '2026-05-22',
+    category: 'commands',
+    command: '!unresolved',
+    settingKey: 'commandWon',
+    deepLink: { path: '/dashboard/commands' },
+    demo: {
+      chat: '2 unresolved match(es) 👌 Use !won or !lost with match ID: 7654321 (Pudge), 7654320 (Invoker)',
+    },
+  },
+  {
+    id: 'vision-roster',
+    title: 'Sharper !np for high MMR',
+    description:
+      "For 8500+ MMR games where the draft isn't visible, Dotabod now reads the in-game hero bar to fill in the player roster more accurately.",
+    releaseDate: '2026-05-22',
+    category: 'overlay',
+    command: '!np',
+    deepLink: { path: '/dashboard/commands' },
+  },
+  {
+    id: 'lastfm-fix',
+    title: 'Last.fm overlay fixes',
+    description:
+      'Track, artist, and album names with special characters (apostrophes, ampersands) now display correctly in the Last.fm now-playing overlay.',
+    releaseDate: '2026-05-22',
+    category: 'overlay',
+    settingKey: 'lastFmOverlay',
+    deepLink: { path: '/dashboard/features/overlay' },
+  },
+  {
+    id: 'help-redesign',
+    title: 'Searchable help center',
+    description:
+      'The troubleshooting page is now a searchable, categorized help center with clearer Steam and overlay setup steps.',
+    releaseDate: '2026-05-20',
+    category: 'pages',
+    deepLink: { path: '/dashboard/help' },
+  },
+  {
+    id: 'crypto-nowpayments',
+    title: 'Crypto payments, improved',
+    description:
+      'Crypto checkout moved to NOWPayments — more supported coins and a smoother payment flow.',
+    releaseDate: '2026-05-20',
+    category: 'advanced',
+    blogSlug: 'crypto-payments-nowpayments',
+    deepLink: { path: '/dashboard/billing' },
+  },
+  {
+    id: 'recent-command',
+    title: '!recent match history',
+    description:
+      'Lists the last 5 resolved matches from this stream with their match IDs, hero, and result. Shares the toggle with !won.',
+    releaseDate: '2026-05-19',
+    category: 'commands',
+    command: '!recent',
+    settingKey: 'commandWon',
+    deepLink: { path: '/dashboard/commands' },
+    demo: { chat: 'Recent matches: 7654321 W (Pudge), 7654320 L (Invoker), 7654319 W (Sniper) 👌' },
+  },
+  {
+    id: 'command-toggles',
+    title: 'Toggle more commands',
+    description:
+      'Around a dozen more commands (!geo, !stats, !match, !friends, !count, and more) can now be turned on or off individually from the dashboard.',
+    releaseDate: '2026-05-19',
+    category: 'commands',
+    deepLink: { path: '/dashboard/commands' },
+  },
+  {
+    id: 'steam-connector',
+    title: 'One-click Steam connect',
+    description:
+      'A new connector auto-links your Steam account while you stream, with live status and built-in troubleshooting.',
+    releaseDate: '2026-05-17',
+    category: 'stream',
+    deepLink: { path: '/dashboard' },
+  },
+  {
+    id: 'billing-status',
+    title: 'Clearer billing status',
+    description:
+      'Subscription status is clearer for past-due, cancelled, and paused states, with better messaging and retry prompts.',
+    releaseDate: '2026-03-06',
+    category: 'advanced',
+    deepLink: { path: '/dashboard/billing' },
+  },
+  {
+    id: 'regional-blocking',
+    title: 'Regional blocking warning',
+    description:
+      'Streamers in regions that block our overlay host now get an in-dashboard warning with remediation steps.',
+    releaseDate: '2026-02-10',
+    category: 'stream',
+    deepLink: { path: '/dashboard' },
+  },
+  {
+    id: 'lead-mod',
+    title: 'Lead Moderator support',
+    description:
+      "Dotabod now recognizes Twitch's Lead Moderator badge for mod-only commands and chat permissions.",
+    releaseDate: '2026-01-20',
+    category: 'chat',
+    deepLink: { path: '/dashboard/commands' },
+  },
+  {
+    id: 'today-command',
+    title: '!today hero stats',
+    description: 'Shows wins and losses per hero played today.',
+    releaseDate: '2026-01-06',
+    category: 'commands',
+    command: '!today',
+    settingKey: 'commandToday',
+    deepLink: { path: '/dashboard/commands' },
+    demo: { chat: 'Pudge 2-1 · Invoker 1-0 · Sniper 0-2 · 3W 3L (6 games)' },
+  },
 ]
 
 // Newest-first ordering, reused by the dashboard page, public page, and home teaser.

--- a/src/lib/whatsNew.ts
+++ b/src/lib/whatsNew.ts
@@ -289,3 +289,21 @@ export function entryToggleChecked(
 ): boolean | undefined {
   return entry.followsNewFeatureMaster ? (value ?? master) : Boolean(value)
 }
+
+// Button label for a deep-link, named for its destination rather than a generic "settings".
+// Real entries are all covered by the map below (enforced in whatsNew.test.ts); the fallback
+// humanizes the last path segment so a brand-new destination is never mislabeled as "settings".
+const DEEP_LINK_LABELS: Record<string, string> = {
+  '/dashboard': 'Open dashboard',
+  '/dashboard/billing': 'Open billing',
+  '/dashboard/commands': 'Open commands',
+  '/dashboard/features/overlay': 'Open overlay settings',
+  '/dashboard/help': 'Open help center',
+}
+
+export function deepLinkLabel(deepLink: { path: string }): string {
+  return (
+    DEEP_LINK_LABELS[deepLink.path] ??
+    `Open ${deepLink.path.split('/').filter(Boolean).pop() ?? 'page'}`
+  )
+}

--- a/src/lib/whatsNew.ts
+++ b/src/lib/whatsNew.ts
@@ -1,0 +1,44 @@
+import type { SettingKeys } from '@/lib/defaultSettings'
+
+// One released feature/command/page shown on the "What's New" dashboard surface. `id` is
+// shared by convention with the backend FEATURE_ANNOUNCEMENTS registry (the two repos have no
+// shared package, same as setting keys). Newest entries go to the top via `releaseDate`.
+export interface WhatsNewEntry {
+  id: string
+  title: string
+  description: string
+  releaseDate: string // ISO (yyyy-mm-dd)
+  category: 'chat' | 'overlay' | 'commands' | 'pages' | 'advanced' | 'bets' | 'mmr' | 'stream'
+  settingKey?: SettingKeys // renders an inline toggle
+  followsNewFeatureMaster?: boolean // tri-state: checked = value ?? autoOptInNewFeatures
+  deepLink?: { path: string; section?: string } // for settings that live on another page
+  command?: string // e.g. '!set'
+  blogSlug?: string // links to /blog/<slug>
+  docsUrl?: string // external "read more"
+  tier?: 'FREE' | 'PRO'
+}
+
+export const whatsNew: WhatsNewEntry[] = [
+  {
+    id: 'cosmetics',
+    title: 'Cosmetic set announcements',
+    description:
+      'When you pick a hero, Dotabod posts your equipped cosmetic set in chat with a link to your public collection. Viewers can also type !set anytime.',
+    releaseDate: '2026-06-10',
+    category: 'chat',
+    settingKey: 'cosmeticsAnnounce',
+    followsNewFeatureMaster: true,
+    command: '!set',
+    tier: 'FREE',
+  },
+]
+
+// Effective toggle state for a What's New entry: new-feature toggles follow the master
+// (autoOptInNewFeatures) until explicitly set; everything else uses its own stored value.
+export function entryToggleChecked(
+  entry: WhatsNewEntry,
+  value: boolean | null | undefined,
+  master: boolean | undefined,
+): boolean | undefined {
+  return entry.followsNewFeatureMaster ? (value ?? master) : Boolean(value)
+}

--- a/src/lib/whatsNew.ts
+++ b/src/lib/whatsNew.ts
@@ -39,10 +39,10 @@ export const whatsNew: WhatsNewEntry[] = [
     demo: {
       chat: 'Invoker set captured! 4 cosmetics → dotabod.com/arteezy/set',
       exampleUrl: 'https://dotabod.com/arteezy/set',
-      exampleLabel: "See arteezy's set page →",
+      exampleLabel: "See arteezy's set page",
     },
     details: [
-      "Every hero pick or mid-game swap (while you're live) snapshots your equipped wearables to your collection — one entry per hero, refreshed each time you replay it. No need for chat to run !set.",
+      "Every hero pick or mid-game swap (while you're live) snapshots your equipped wearables to your collection, one entry per hero, refreshed each time you replay it. No need for chat to run !set.",
       "It posts in chat at most once per match per hero, and !set re-snapshots your current hero on demand. Your public page at dotabod.com/<name>/set shows every hero you've captured.",
     ],
   },
@@ -50,22 +50,22 @@ export const whatsNew: WhatsNewEntry[] = [
     id: 'cosmetic-set-pages',
     title: 'Hero cosmetic set pages',
     description:
-      "Browse any streamer's equipped cosmetics hero-by-hero — with rarity, a completion meter, and a trophy tally — on their public set page.",
+      "Browse any streamer's equipped cosmetics hero by hero on their public set page, with rarity, a completion meter, and a trophy tally.",
     releaseDate: '2026-06-02',
     category: 'pages',
     demo: {
       exampleUrl: 'https://dotabod.com/arteezy/set',
-      exampleLabel: "Browse arteezy's collection →",
+      exampleLabel: "Browse arteezy's collection",
     },
     details: [
-      'The page reads your captured loadouts and groups them by hero, with rarity, a completion meter, and a trophy tally. It fills in automatically as you play (or run !set) — the more heroes you pick on stream, the more complete it gets.',
+      'The page reads your captured loadouts and groups them by hero, with rarity, a completion meter, and a trophy tally. It fills in as you play or run !set, so the more heroes you pick on stream, the more complete it gets.',
     ],
   },
   {
     id: 'paypal',
     title: 'PayPal for Dotabod Pro',
     description:
-      'You can now subscribe to — or gift — Dotabod Pro with PayPal (monthly, annual, or lifetime), right alongside card and crypto.',
+      'You can now subscribe to (or gift) Dotabod Pro with PayPal, monthly, annual, or lifetime, alongside card and crypto.',
     releaseDate: '2026-05-28',
     category: 'advanced',
     blogSlug: 'paypal-payments',
@@ -80,22 +80,22 @@ export const whatsNew: WhatsNewEntry[] = [
     category: 'pages',
     demo: {
       exampleUrl: 'https://dotabod.com/streamers',
-      exampleLabel: 'Browse the directory →',
+      exampleLabel: 'Browse the directory',
     },
     details: [
-      'Lists Dotabod streamers publicly, filterable by rank and sortable by follower count — a way for viewers to discover others using Dotabod, and for the network to show up in search.',
+      'Lists Dotabod streamers publicly, filterable by rank and sortable by follower count. Viewers can find others using Dotabod, and the network shows up in search.',
     ],
   },
   {
     id: 'gift-redesign',
     title: 'Redesigned gifting',
     description:
-      'Gifting Pro got a cleaner flow: a live chat preview, preset durations, and a running price summary before checkout.',
+      'Gifting Pro has a cleaner flow, with a live chat preview, preset durations, and a running price summary before checkout.',
     releaseDate: '2026-05-30',
     category: 'pages',
     demo: {
       exampleUrl: 'https://dotabod.com/arteezy/gift',
-      exampleLabel: "See arteezy's gift page →",
+      exampleLabel: "See arteezy's gift page",
     },
   },
   {
@@ -124,15 +124,15 @@ export const whatsNew: WhatsNewEntry[] = [
     deepLink: { path: '/dashboard/commands' },
     demo: { chat: 'Playing with 2 other Dotabod streamers Okayge' },
     details: [
-      'Counts other Dotabod-registered users in your match from two sources — live broadcasters sending GSI for that match, plus the SourceTV roster — and never shows names, to avoid cross-chat drama.',
-      'Pro adds two extras: a " · N other streamer(s)" suffix on !np, and an automatic heads-up in chat about other streamers ~90 seconds after the match starts.',
+      'Counts other Dotabod-registered users in your match (live broadcasters sending GSI, plus the SourceTV roster) and never shows names, to avoid cross-chat drama.',
+      'Pro adds a " · N other streamer(s)" suffix on !np, plus an automatic heads-up in chat about other streamers ~90 seconds after the match starts.',
     ],
   },
   {
     id: 'mod-resolution',
     title: 'Easier bet resolution',
     description:
-      '!unresolved now lists pending matches with KDA, length, and match IDs, and a bare !won or !lost flips your most recent match — no match ID needed.',
+      '!unresolved now lists pending matches with KDA, length, and match IDs, and a bare !won or !lost flips your most recent match, no match ID needed.',
     releaseDate: '2026-05-22',
     category: 'commands',
     command: '!unresolved',
@@ -142,7 +142,7 @@ export const whatsNew: WhatsNewEntry[] = [
       chat: '2 unresolved match(es) 👌 Use !won or !lost with match ID: 7654321 (Pudge), 7654320 (Invoker)',
     },
     details: [
-      'A bare !won or !lost (no match ID) resolves the most recent finished match of your current stream session — handy when Dotabod disconnected before the match ended. Re-resolving a match doubles the MMR change to undo the old result and apply the new one.',
+      'A bare !won or !lost (no match ID) resolves the most recent finished match of your current stream session, handy when Dotabod disconnected before the match ended. Re-resolving a match doubles the MMR change to undo the old result and apply the new one.',
       "!unresolved lists this session's matches with no recorded result, newest first (up to 10), each with hero, K/D/A, score, length, and the match ID to pass to !won or !lost.",
     ],
   },
@@ -160,7 +160,7 @@ export const whatsNew: WhatsNewEntry[] = [
     },
     details: [
       'Kicks in for Immortal / 8500+ MMR games, where Valve hides the public draft. Dotabod auto-captures short overlay clips at draft (~46s), the strategy phase (~50s), and ~60s into the game.',
-      'Its Vision service reads the in-game hero bar — the row of ~60px portraits — and returns up to 10 heroes with a per-slot confidence score, falling back to draft player names until heroes load. Vision-detected heroes take priority when building the !np roster.',
+      'Its Vision service reads the in-game hero bar (the row of ~60px portraits) and returns up to 10 heroes with a per-slot confidence score, falling back to draft player names until heroes load. Vision-detected heroes take priority when building the !np roster.',
     ],
   },
   {
@@ -190,7 +190,7 @@ export const whatsNew: WhatsNewEntry[] = [
     id: 'crypto-nowpayments',
     title: 'Crypto payments, improved',
     description:
-      'Crypto checkout moved to NOWPayments — more supported coins and a smoother payment flow.',
+      'Crypto checkout moved to NOWPayments, with more supported coins and a smoother payment flow.',
     releaseDate: '2026-05-20',
     category: 'advanced',
     blogSlug: 'crypto-payments-nowpayments',
@@ -290,9 +290,7 @@ export function entryToggleChecked(
   return entry.followsNewFeatureMaster ? (value ?? master) : Boolean(value)
 }
 
-// Button label for a deep-link, named for its destination rather than a generic "settings".
-// Real entries are all covered by the map below (enforced in whatsNew.test.ts); the fallback
-// humanizes the last path segment so a brand-new destination is never mislabeled as "settings".
+// Human label for a deep-link's destination, used by the card's "Open …" button.
 const DEEP_LINK_LABELS: Record<string, string> = {
   '/dashboard': 'Open dashboard',
   '/dashboard/billing': 'Open billing',

--- a/src/lib/whatsNew.ts
+++ b/src/lib/whatsNew.ts
@@ -33,6 +33,11 @@ export const whatsNew: WhatsNewEntry[] = [
   },
 ]
 
+// Newest-first ordering, reused by the dashboard page, public page, and home teaser.
+export const whatsNewSorted = [...whatsNew].sort(
+  (a, b) => new Date(b.releaseDate).getTime() - new Date(a.releaseDate).getTime(),
+)
+
 // Effective toggle state for a What's New entry: new-feature toggles follow the master
 // (autoOptInNewFeatures) until explicitly set; everything else uses its own stored value.
 export function entryToggleChecked(

--- a/src/lib/whatsNew.ts
+++ b/src/lib/whatsNew.ts
@@ -16,6 +16,9 @@ export interface WhatsNewEntry {
   blogSlug?: string // links to /blog/<slug>
   docsUrl?: string // external "read more"
   tier?: 'FREE' | 'PRO'
+  // A live demo so people see what the feature actually does: a sample of what it posts
+  // and/or a link to a real example page.
+  demo?: { chat?: string; exampleUrl?: string; exampleLabel?: string }
 }
 
 export const whatsNew: WhatsNewEntry[] = [
@@ -30,6 +33,11 @@ export const whatsNew: WhatsNewEntry[] = [
     followsNewFeatureMaster: true,
     command: '!set',
     tier: 'FREE',
+    demo: {
+      chat: 'Invoker set captured! 4 cosmetics → dotabod.com/arteezy/set',
+      exampleUrl: 'https://dotabod.com/arteezy/set',
+      exampleLabel: "See arteezy's set page →",
+    },
   },
 ]
 

--- a/src/lib/whatsNew.ts
+++ b/src/lib/whatsNew.ts
@@ -19,6 +19,9 @@ export interface WhatsNewEntry {
   // A live demo so people see what the feature actually does: a sample of what it posts
   // and/or a link to a real example page.
   demo?: { chat?: string; exampleUrl?: string; exampleLabel?: string }
+  // Deeper "how it works" detail (how/when/limits), shown in a collapsible section under the
+  // excerpt. Each string is rendered as its own paragraph.
+  details?: string[]
 }
 
 export const whatsNew: WhatsNewEntry[] = [
@@ -38,6 +41,10 @@ export const whatsNew: WhatsNewEntry[] = [
       exampleUrl: 'https://dotabod.com/arteezy/set',
       exampleLabel: "See arteezy's set page →",
     },
+    details: [
+      "Every hero pick or mid-game swap (while you're live) snapshots your equipped wearables to your collection — one entry per hero, refreshed each time you replay it. No need for chat to run !set.",
+      "It posts in chat at most once per match per hero, and !set re-snapshots your current hero on demand. Your public page at dotabod.com/<name>/set shows every hero you've captured.",
+    ],
   },
   {
     id: 'cosmetic-set-pages',
@@ -50,6 +57,9 @@ export const whatsNew: WhatsNewEntry[] = [
       exampleUrl: 'https://dotabod.com/arteezy/set',
       exampleLabel: "Browse arteezy's collection →",
     },
+    details: [
+      'The page reads your captured loadouts and groups them by hero, with rarity, a completion meter, and a trophy tally. It fills in automatically as you play (or run !set) — the more heroes you pick on stream, the more complete it gets.',
+    ],
   },
   {
     id: 'paypal',
@@ -72,6 +82,9 @@ export const whatsNew: WhatsNewEntry[] = [
       exampleUrl: 'https://dotabod.com/streamers',
       exampleLabel: 'Browse the directory →',
     },
+    details: [
+      'Lists Dotabod streamers publicly, filterable by rank and sortable by follower count — a way for viewers to discover others using Dotabod, and for the network to show up in search.',
+    ],
   },
   {
     id: 'gift-redesign',
@@ -93,6 +106,11 @@ export const whatsNew: WhatsNewEntry[] = [
     releaseDate: '2026-05-25',
     category: 'chat',
     deepLink: { path: '/dashboard/commands' },
+    demo: { chat: '3311 · Legend☆2 - Average rank this game · Try !smurfs' },
+    details: [
+      'Commands are grouped into related clusters (like !np, !gm, !avg, !smurfs, !ranked). About every 4th time one runs, Dotabod tacks a one-line hint for a sibling command onto its first reply.',
+      "It won't repeat the same suggestion in your channel within 30 minutes, won't suggest the command just used, and only suggests commands you have enabled. Turn it off with the toggle on the commands page.",
+    ],
   },
   {
     id: 'streamers-command',
@@ -105,6 +123,10 @@ export const whatsNew: WhatsNewEntry[] = [
     settingKey: 'commandStreamers',
     deepLink: { path: '/dashboard/commands' },
     demo: { chat: 'Playing with 2 other Dotabod streamers Okayge' },
+    details: [
+      'Counts other Dotabod-registered users in your match from two sources — live broadcasters sending GSI for that match, plus the SourceTV roster — and never shows names, to avoid cross-chat drama.',
+      'Pro adds two extras: a " · N other streamer(s)" suffix on !np, and an automatic heads-up in chat about other streamers ~90 seconds after the match starts.',
+    ],
   },
   {
     id: 'mod-resolution',
@@ -119,6 +141,10 @@ export const whatsNew: WhatsNewEntry[] = [
     demo: {
       chat: '2 unresolved match(es) 👌 Use !won or !lost with match ID: 7654321 (Pudge), 7654320 (Invoker)',
     },
+    details: [
+      'A bare !won or !lost (no match ID) resolves the most recent finished match of your current stream session — handy when Dotabod disconnected before the match ended. Re-resolving a match doubles the MMR change to undo the old result and apply the new one.',
+      "!unresolved lists this session's matches with no recorded result, newest first (up to 10), each with hero, K/D/A, score, length, and the match ID to pass to !won or !lost.",
+    ],
   },
   {
     id: 'vision-roster',
@@ -129,6 +155,13 @@ export const whatsNew: WhatsNewEntry[] = [
     category: 'overlay',
     command: '!np',
     deepLink: { path: '/dashboard/commands' },
+    demo: {
+      chat: 'All Pick: DuBu (Shadow Shaman) · Collapse (Magnus) · Puppy (Chen) · PPD (Tusk) · Rajjix (Timbersaw)',
+    },
+    details: [
+      'Kicks in for Immortal / 8500+ MMR games, where Valve hides the public draft. Dotabod auto-captures short overlay clips at draft (~46s), the strategy phase (~50s), and ~60s into the game.',
+      'Its Vision service reads the in-game hero bar — the row of ~60px portraits — and returns up to 10 heroes with a per-slot confidence score, falling back to draft player names until heroes load. Vision-detected heroes take priority when building the !np roster.',
+    ],
   },
   {
     id: 'lastfm-fix',
@@ -139,6 +172,10 @@ export const whatsNew: WhatsNewEntry[] = [
     category: 'overlay',
     settingKey: 'lastFmOverlay',
     deepLink: { path: '/dashboard/features/overlay' },
+    demo: { chat: "Now playing: Guns N' Roses - Sweet Child O' Mine (Appetite for Destruction)" },
+    details: [
+      "Last.fm's API returns names with HTML entities (like &#39; for an apostrophe). Dotabod now decodes those on the way in and stops re-escaping them on the way out to Twitch, so apostrophes and ampersands show as real characters instead of &#39; / &amp;.",
+    ],
   },
   {
     id: 'help-redesign',
@@ -179,6 +216,9 @@ export const whatsNew: WhatsNewEntry[] = [
     releaseDate: '2026-05-19',
     category: 'commands',
     deepLink: { path: '/dashboard/commands' },
+    details: [
+      'Commands like !geo, !stats, !match, !friends, !count, and !fixdbl each got their own on/off switch in the dashboard, so you can tailor exactly which ones your chat can use.',
+    ],
   },
   {
     id: 'steam-connector',
@@ -188,6 +228,9 @@ export const whatsNew: WhatsNewEntry[] = [
     releaseDate: '2026-05-17',
     category: 'stream',
     deepLink: { path: '/dashboard' },
+    details: [
+      "The connector polls for your active Steam account while you stream and links it automatically, with status feedback and built-in troubleshooting if it doesn't appear.",
+    ],
   },
   {
     id: 'billing-status',
@@ -215,6 +258,9 @@ export const whatsNew: WhatsNewEntry[] = [
     releaseDate: '2026-01-20',
     category: 'chat',
     deepLink: { path: '/dashboard/commands' },
+    details: [
+      "Twitch's Lead Moderator is a separate badge from a regular mod. Dotabod now grants Lead Moderators mod-level access to mod-only commands like !won, !toggle, and !modsonly.",
+    ],
   },
   {
     id: 'today-command',

--- a/src/lib/whatsNew.ts
+++ b/src/lib/whatsNew.ts
@@ -1,4 +1,4 @@
-import type { SettingKeys } from '@/lib/defaultSettings'
+import type { CommandKeys, SettingKeys } from '@/lib/defaultSettings'
 
 // One released feature/command/page shown on the "What's New" dashboard surface. `id` is
 // shared by convention with the backend FEATURE_ANNOUNCEMENTS registry (the two repos have no
@@ -19,6 +19,10 @@ export interface WhatsNewEntry {
   // A live demo so people see what the feature actually does: a sample of what it posts
   // and/or a link to a real example page.
   demo?: { chat?: string; exampleUrl?: string; exampleLabel?: string }
+  // For command features, point at the real command in CommandDetail so the example renders
+  // the same <TwitchChat> sample the commands page uses, keeping its flag/emote/emoji images
+  // instead of a hand-copied text line. Takes precedence over demo.chat.
+  demoCommand?: CommandKeys
   // Deeper "how it works" detail (how/when/limits), shown in a collapsible section under the
   // excerpt. Each string is rendered as its own paragraph.
   details?: string[]
@@ -36,8 +40,8 @@ export const whatsNew: WhatsNewEntry[] = [
     followsNewFeatureMaster: true,
     command: '!set',
     tier: 'FREE',
+    demoCommand: 'commandSet',
     demo: {
-      chat: 'Invoker set captured! 4 cosmetics → dotabod.com/arteezy/set',
       exampleUrl: 'https://dotabod.com/arteezy/set',
       exampleLabel: "See arteezy's set page",
     },
@@ -122,7 +126,7 @@ export const whatsNew: WhatsNewEntry[] = [
     command: '!streamers',
     settingKey: 'commandStreamers',
     deepLink: { path: '/dashboard/commands' },
-    demo: { chat: 'Playing with 2 other Dotabod streamers Okayge' },
+    demoCommand: 'commandStreamers',
     details: [
       'Counts other Dotabod-registered users in your match (live broadcasters sending GSI, plus the SourceTV roster) and never shows names, to avoid cross-chat drama.',
       'Pro adds a " · N other streamer(s)" suffix on !np, plus an automatic heads-up in chat about other streamers ~90 seconds after the match starts.',
@@ -138,9 +142,7 @@ export const whatsNew: WhatsNewEntry[] = [
     command: '!unresolved',
     settingKey: 'commandWon',
     deepLink: { path: '/dashboard/commands' },
-    demo: {
-      chat: '2 unresolved match(es) 👌 Use !won or !lost with match ID: 7654321 (Pudge), 7654320 (Invoker)',
-    },
+    demoCommand: 'commandUnresolved',
     details: [
       'A bare !won or !lost (no match ID) resolves the most recent finished match of your current stream session, handy when Dotabod disconnected before the match ended. Re-resolving a match doubles the MMR change to undo the old result and apply the new one.',
       "!unresolved lists this session's matches with no recorded result, newest first (up to 10), each with hero, K/D/A, score, length, and the match ID to pass to !won or !lost.",
@@ -155,9 +157,7 @@ export const whatsNew: WhatsNewEntry[] = [
     category: 'overlay',
     command: '!np',
     deepLink: { path: '/dashboard/commands' },
-    demo: {
-      chat: 'All Pick: DuBu (Shadow Shaman) · Collapse (Magnus) · Puppy (Chen) · PPD (Tusk) · Rajjix (Timbersaw)',
-    },
+    demoCommand: 'commandNP',
     details: [
       'Kicks in for Immortal / 8500+ MMR games, where Valve hides the public draft. Dotabod auto-captures short overlay clips at draft (~46s), the strategy phase (~50s), and ~60s into the game.',
       'Its Vision service reads the in-game hero bar (the row of ~60px portraits) and returns up to 10 heroes with a per-slot confidence score, falling back to draft player names until heroes load. Vision-detected heroes take priority when building the !np roster.',
@@ -206,7 +206,7 @@ export const whatsNew: WhatsNewEntry[] = [
     command: '!recent',
     settingKey: 'commandWon',
     deepLink: { path: '/dashboard/commands' },
-    demo: { chat: 'Recent matches: 7654321 W (Pudge), 7654320 L (Invoker), 7654319 W (Sniper) 👌' },
+    demoCommand: 'commandRecent',
   },
   {
     id: 'command-toggles',
@@ -271,7 +271,7 @@ export const whatsNew: WhatsNewEntry[] = [
     command: '!today',
     settingKey: 'commandToday',
     deepLink: { path: '/dashboard/commands' },
-    demo: { chat: 'Pudge 2-1 · Invoker 1-0 · Sniper 0-2 · 3W 3L (6 games)' },
+    demoCommand: 'commandToday',
   },
 ]
 

--- a/src/pages/api/notifications.ts
+++ b/src/pages/api/notifications.ts
@@ -88,7 +88,6 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
 
         return res.status(200).json({
           hasLifetime,
-          hasNotification: notifications.some((n) => n !== null && !n.read),
           notifications,
           totalNotifications: notifications.length,
         })

--- a/src/pages/api/notifications.ts
+++ b/src/pages/api/notifications.ts
@@ -5,7 +5,10 @@ import { withMethods } from '@/lib/api-middlewares/with-methods'
 import { authOptions } from '@/lib/auth'
 import prisma from '@/lib/db'
 
-// Schema for marking a notification as read
+// Single notifications endpoint for the dashboard. Returns every notification type the
+// user has (gift subscriptions + new-feature heads-ups, …), each mapped to a
+// type-discriminated shape consumers switch on, plus the gift `hasLifetime` aggregate.
+// The bell renders all types; the gift toast in DashboardShell filters to GIFT_SUBSCRIPTION.
 const markAsReadSchema = z.object({
   notificationId: z.string(),
 })
@@ -14,23 +17,17 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
   try {
     const session = await getServerSession(req, res, authOptions)
     if (!session?.user?.id) {
-      console.log('Unauthorized access attempt to gift notifications')
       return res.status(401).json({ message: 'Unauthorized' })
     }
 
     const userId = session.user.id
 
-    // GET: Fetch gift notifications and subscription status
     if (req.method === 'GET') {
       try {
         res.setHeader('Cache-Control', 'private, max-age=15, stale-while-revalidate=30')
-
-        // Check if we should include read notifications
         const includeRead = req.query.includeRead === 'true'
 
-        // Find notifications of type GIFT_SUBSCRIPTION
-        // Only filter by isRead if includeRead is false
-        const notifications = await prisma.notification.findMany({
+        const rows = await prisma.notification.findMany({
           include: {
             giftSubscription: true,
           },
@@ -38,13 +35,13 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
             createdAt: 'desc',
           },
           where: {
-            type: 'GIFT_SUBSCRIPTION',
+            type: { in: ['GIFT_SUBSCRIPTION', 'NEW_FEATURE'] },
             userId,
             ...(includeRead ? {} : { isRead: false }),
           },
         })
 
-        // Get active subscriptions to check if user has lifetime
+        // Gift aggregate still surfaced here (consumed by the gift toast + admin page).
         const activeSubscriptions = await prisma.subscription.findMany({
           include: {
             giftDetails: true,
@@ -54,49 +51,55 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
             userId,
           },
         })
-
-        // Check if user has a lifetime subscription
         const hasLifetime = activeSubscriptions.some(
           (sub) =>
             sub.giftDetails?.giftType === 'lifetime' ||
             (sub.tier === 'PRO' && sub.transactionType === 'LIFETIME'),
         )
 
-        // Format notifications for frontend
-        const formattedNotifications = notifications
-          .map((notification) => {
-            if (!notification.giftSubscription) {
+        const notifications = rows
+          .map((n) => {
+            if (n.type === 'NEW_FEATURE') {
+              return {
+                createdAt: n.createdAt,
+                id: n.id,
+                read: n.isRead,
+                type: 'NEW_FEATURE' as const,
+              }
+            }
+
+            // GIFT_SUBSCRIPTION — drop orphaned rows whose gift was deleted.
+            if (!n.giftSubscription) {
               return null
             }
 
             return {
-              createdAt: notification.createdAt,
-              giftMessage: notification.giftSubscription.giftMessage,
-              giftQuantity: notification.giftSubscription.giftQuantity || 1,
-              giftType: notification.giftSubscription.giftType,
-              id: notification.id,
-              read: notification.isRead, // Include read status in the response
-              senderName: notification.giftSubscription.senderName,
+              createdAt: n.createdAt,
+              giftMessage: n.giftSubscription.giftMessage,
+              giftQuantity: n.giftSubscription.giftQuantity || 1,
+              giftType: n.giftSubscription.giftType,
+              id: n.id,
+              read: n.isRead,
+              senderName: n.giftSubscription.senderName,
+              type: 'GIFT_SUBSCRIPTION' as const,
             }
           })
           .filter(Boolean)
 
         return res.status(200).json({
           hasLifetime,
-          hasNotification: formattedNotifications.some((n) => n !== null && !n.read), // Check for null before accessing read property
-          notifications: formattedNotifications,
-          totalNotifications: formattedNotifications.length,
+          hasNotification: notifications.some((n) => n !== null && !n.read),
+          notifications,
+          totalNotifications: notifications.length,
         })
       } catch (error) {
-        console.error('Error fetching gift notifications:', error)
+        console.error('Error fetching notifications:', error)
         return res.status(500).json({ error: String(error), message: 'Internal server error' })
       }
     }
 
-    // POST: Mark a notification as read
     if (req.method === 'POST') {
       try {
-        // Validate request body
         const validationResult = markAsReadSchema.safeParse(req.body)
         if (!validationResult.success) {
           return res
@@ -106,7 +109,7 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
 
         const { notificationId } = validationResult.data
 
-        // Find the notification and ensure it belongs to the user
+        // Scope the update to the caller's own notifications.
         const notification = await prisma.notification.findFirst({
           where: {
             id: notificationId,
@@ -118,7 +121,6 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
           return res.status(404).json({ message: 'Notification not found' })
         }
 
-        // Mark notification as read
         await prisma.notification.update({
           data: {
             isRead: true,
@@ -138,7 +140,7 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
 
     return res.status(405).json({ message: 'Method not allowed' })
   } catch (error) {
-    console.error('Unexpected error in gift notifications API:', error)
+    console.error('Unexpected error in notifications API:', error)
     return res.status(500).json({ error: String(error), message: 'Internal server error' })
   }
 }

--- a/src/pages/dashboard/admin/test-gift.tsx
+++ b/src/pages/dashboard/admin/test-gift.tsx
@@ -37,7 +37,7 @@ const TestGiftPage: NextPageWithLayout = () => {
 
   // Fetch subscription status to check if user has lifetime
   const { data: giftNotificationData } = useSWR(
-    status === 'authenticated' ? '/api/gift-notifications' : null,
+    status === 'authenticated' ? '/api/notifications' : null,
     fetcher,
     STABLE_SWR_OPTIONS,
   )

--- a/src/pages/dashboard/features/index.tsx
+++ b/src/pages/dashboard/features/index.tsx
@@ -5,6 +5,7 @@ import BetsCard from '@/components/Dashboard/Features/BetsCard'
 import IdeaCard from '@/components/Dashboard/Features/IdeaCard'
 import LanguageCard from '@/components/Dashboard/Features/LanguageCard'
 import MmrTrackerCard from '@/components/Dashboard/Features/MmrTrackerCard'
+import NewFeaturesCard from '@/components/Dashboard/Features/NewFeaturesCard'
 import { RankOnlyCard } from '@/components/Dashboard/Features/RankOnlyCard'
 import StreamDelayCard from '@/components/Dashboard/Features/StreamDelay'
 import Header from '@/components/Dashboard/Header'
@@ -44,6 +45,11 @@ const FeaturesPage: NextPageWithLayout = () => (
       <div id='rank-only'>
         <ErrorBoundary>
           <RankOnlyCard />
+        </ErrorBoundary>
+      </div>
+      <div id='new-features'>
+        <ErrorBoundary>
+          <NewFeaturesCard />
         </ErrorBoundary>
       </div>
       <ErrorBoundary>

--- a/src/pages/dashboard/index.tsx
+++ b/src/pages/dashboard/index.tsx
@@ -14,6 +14,7 @@ import DashboardShell from '@/components/Dashboard/DashboardShell'
 import ExportCFG from '@/components/Dashboard/ExportCFG'
 import Header from '@/components/Dashboard/Header'
 import OBSOverlay from '@/components/Dashboard/OBSOverlay'
+import WhatsNewTeaser from '@/components/Dashboard/WhatsNewTeaser'
 import { fetcher } from '@/lib/fetcher'
 import { useSetupModStatus } from '@/lib/hooks/useSetupModStatus'
 import { useSteamLinkedAccount } from '@/lib/hooks/useSteamLinkedAccount'
@@ -382,6 +383,8 @@ const SetupPage = () => {
         }
         title='Setup'
       />
+
+      <WhatsNewTeaser />
 
       <div className='mb-4'>
         <Progress

--- a/src/pages/dashboard/whats-new.tsx
+++ b/src/pages/dashboard/whats-new.tsx
@@ -8,15 +8,13 @@ import ErrorBoundary from '@/components/ErrorBoundary'
 import { Settings } from '@/lib/defaultSettings'
 import { useUpdateSetting } from '@/lib/hooks/useUpdateSetting'
 import { requireDashboardAccess } from '@/lib/server/dashboardAccess'
-import { whatsNew } from '@/lib/whatsNew'
+import { whatsNewSorted } from '@/lib/whatsNew'
 import type { NextPageWithLayout } from '@/pages/_app'
 import { Card } from '@/ui/card'
 
 const WhatsNewPage: NextPageWithLayout = () => {
   const { data: master } = useUpdateSetting<boolean>(Settings.autoOptInNewFeatures)
-  const entries = [...whatsNew].sort(
-    (a, b) => new Date(b.releaseDate).getTime() - new Date(a.releaseDate).getTime(),
-  )
+  const entries = whatsNewSorted
 
   return (
     <>

--- a/src/pages/dashboard/whats-new.tsx
+++ b/src/pages/dashboard/whats-new.tsx
@@ -1,0 +1,68 @@
+import Head from 'next/head'
+import type { ReactElement } from 'react'
+import DashboardShell from '@/components/Dashboard/DashboardShell'
+import { TierSwitch } from '@/components/Dashboard/Features/TierSwitch'
+import WhatsNewFeatureCard from '@/components/Dashboard/Features/WhatsNewFeatureCard'
+import Header from '@/components/Dashboard/Header'
+import ErrorBoundary from '@/components/ErrorBoundary'
+import { Settings } from '@/lib/defaultSettings'
+import { useUpdateSetting } from '@/lib/hooks/useUpdateSetting'
+import { requireDashboardAccess } from '@/lib/server/dashboardAccess'
+import { whatsNew } from '@/lib/whatsNew'
+import type { NextPageWithLayout } from '@/pages/_app'
+import { Card } from '@/ui/card'
+
+const WhatsNewPage: NextPageWithLayout = () => {
+  const { data: master } = useUpdateSetting<boolean>(Settings.autoOptInNewFeatures)
+  const entries = [...whatsNew].sort(
+    (a, b) => new Date(b.releaseDate).getTime() - new Date(a.releaseDate).getTime(),
+  )
+
+  return (
+    <>
+      <Head>
+        <title>Dotabod | What&apos;s new</title>
+      </Head>
+      <Header
+        title="What's new"
+        subtitle='The latest Dotabod features, commands, and pages — newest first. Flip any of them on or off right here.'
+      />
+
+      <Card className='mb-6'>
+        <TierSwitch
+          settingKey={Settings.autoOptInNewFeatures}
+          label='Automatically enable new features as they launch'
+        />
+      </Card>
+
+      <div className='grid grid-cols-1 gap-6 lg:grid-cols-2'>
+        {entries.map((entry, i) => (
+          <div id={entry.id} key={entry.id}>
+            <ErrorBoundary>
+              <WhatsNewFeatureCard entry={entry} master={master} latest={i === 0} />
+            </ErrorBoundary>
+          </div>
+        ))}
+      </div>
+    </>
+  )
+}
+
+WhatsNewPage.getLayout = function getLayout(page: ReactElement) {
+  return (
+    <DashboardShell
+      seo={{
+        canonicalUrl: 'https://dotabod.com/dashboard/whats-new',
+        description: 'The latest Dotabod features, commands, and pages.',
+        noindex: true,
+        title: "What's New | Dotabod",
+      }}
+    >
+      {page}
+    </DashboardShell>
+  )
+}
+
+export const getServerSideProps = requireDashboardAccess()
+
+export default WhatsNewPage

--- a/src/pages/dashboard/whats-new.tsx
+++ b/src/pages/dashboard/whats-new.tsx
@@ -23,7 +23,7 @@ const WhatsNewPage: NextPageWithLayout = () => {
       </Head>
       <Header
         title="What's new"
-        subtitle='The latest Dotabod features, commands, and pages — newest first. Flip any of them on or off right here.'
+        subtitle='The latest Dotabod features, commands, and pages. Flip any of them on or off right here.'
       />
 
       <Card className='mb-6'>

--- a/src/pages/whats-new.tsx
+++ b/src/pages/whats-new.tsx
@@ -11,7 +11,7 @@ const { Title, Paragraph } = Typography
 
 const pageTitle = "What's New | Dotabod"
 const pageDescription =
-  'The latest Dotabod features, commands, and pages — follow along as they ship.'
+  'The latest Dotabod features, commands, and pages. Follow along as they ship.'
 const canonicalUrl = 'https://dotabod.com/whats-new'
 
 // Public, indexable changelog so anyone (logged in or not) can follow new releases. Same
@@ -28,7 +28,7 @@ const WhatsNewPublic: NextPageWithLayout = () => {
         <Paragraph className='mb-8 text-lg'>
           The latest Dotabod features, commands, and pages.{' '}
           <Link href='/dashboard/whats-new' className='text-purple-400 hover:text-purple-300'>
-            Manage them in your dashboard →
+            Manage them in your dashboard
           </Link>
         </Paragraph>
 

--- a/src/pages/whats-new.tsx
+++ b/src/pages/whats-new.tsx
@@ -1,5 +1,4 @@
 import { Typography } from 'antd'
-import Head from 'next/head'
 import Link from 'next/link'
 import type { ReactElement } from 'react'
 import { Container } from '@/components/Container'
@@ -20,43 +19,28 @@ const canonicalUrl = 'https://dotabod.com/whats-new'
 const WhatsNewPublic: NextPageWithLayout = () => {
   const entries = whatsNewSorted
 
+  // SEO (title/description/canonical/OG/Twitter) is rendered by HomepageShell from the
+  // `seo` prop in getLayout below — no inline <Head> needed.
   return (
-    <>
-      <Head>
-        <title>{pageTitle}</title>
-        <meta name='description' content={pageDescription} />
-        <link rel='canonical' href={canonicalUrl} />
+    <Container className='pb-16'>
+      <div className='mx-auto max-w-3xl'>
+        <Title level={1}>What&apos;s new</Title>
+        <Paragraph className='mb-8 text-lg'>
+          The latest Dotabod features, commands, and pages — newest first.{' '}
+          <Link href='/dashboard/whats-new' className='text-purple-400 hover:text-purple-300'>
+            Manage them in your dashboard →
+          </Link>
+        </Paragraph>
 
-        <meta property='og:type' content='website' />
-        <meta property='og:url' content={canonicalUrl} />
-        <meta property='og:title' content={pageTitle} />
-        <meta property='og:description' content={pageDescription} />
-
-        <meta property='twitter:card' content='summary_large_image' />
-        <meta property='twitter:url' content={canonicalUrl} />
-        <meta property='twitter:title' content={pageTitle} />
-        <meta property='twitter:description' content={pageDescription} />
-      </Head>
-      <Container className='pb-16'>
-        <div className='mx-auto max-w-3xl'>
-          <Title level={1}>What&apos;s new</Title>
-          <Paragraph className='mb-8 text-lg'>
-            The latest Dotabod features, commands, and pages — newest first.{' '}
-            <Link href='/dashboard/whats-new' className='text-purple-400 hover:text-purple-300'>
-              Manage them in your dashboard →
-            </Link>
-          </Paragraph>
-
-          <div className='grid grid-cols-1 gap-6'>
-            {entries.map((entry, i) => (
-              <div id={entry.id} key={entry.id}>
-                <WhatsNewFeatureCard entry={entry} latest={i === 0} readOnly />
-              </div>
-            ))}
-          </div>
+        <div className='grid grid-cols-1 gap-6'>
+          {entries.map((entry, i) => (
+            <div id={entry.id} key={entry.id}>
+              <WhatsNewFeatureCard entry={entry} latest={i === 0} readOnly />
+            </div>
+          ))}
         </div>
-      </Container>
-    </>
+      </div>
+    </Container>
   )
 }
 

--- a/src/pages/whats-new.tsx
+++ b/src/pages/whats-new.tsx
@@ -26,7 +26,7 @@ const WhatsNewPublic: NextPageWithLayout = () => {
       <div className='mx-auto max-w-3xl'>
         <Title level={1}>What&apos;s new</Title>
         <Paragraph className='mb-8 text-lg'>
-          The latest Dotabod features, commands, and pages — newest first.{' '}
+          The latest Dotabod features, commands, and pages.{' '}
           <Link href='/dashboard/whats-new' className='text-purple-400 hover:text-purple-300'>
             Manage them in your dashboard →
           </Link>

--- a/src/pages/whats-new.tsx
+++ b/src/pages/whats-new.tsx
@@ -5,7 +5,7 @@ import type { ReactElement } from 'react'
 import { Container } from '@/components/Container'
 import WhatsNewFeatureCard from '@/components/Dashboard/Features/WhatsNewFeatureCard'
 import HomepageShell from '@/components/Homepage/HomepageShell'
-import { whatsNew } from '@/lib/whatsNew'
+import { whatsNewSorted } from '@/lib/whatsNew'
 import type { NextPageWithLayout } from '@/pages/_app'
 
 const { Title, Paragraph } = Typography
@@ -18,9 +18,7 @@ const canonicalUrl = 'https://dotabod.com/whats-new'
 // Public, indexable changelog so anyone (logged in or not) can follow new releases. Same
 // registry + cards as the dashboard page, rendered read-only (no toggles).
 const WhatsNewPublic: NextPageWithLayout = () => {
-  const entries = [...whatsNew].sort(
-    (a, b) => new Date(b.releaseDate).getTime() - new Date(a.releaseDate).getTime(),
-  )
+  const entries = whatsNewSorted
 
   return (
     <>

--- a/src/pages/whats-new.tsx
+++ b/src/pages/whats-new.tsx
@@ -1,0 +1,76 @@
+import { Typography } from 'antd'
+import Head from 'next/head'
+import Link from 'next/link'
+import type { ReactElement } from 'react'
+import { Container } from '@/components/Container'
+import WhatsNewFeatureCard from '@/components/Dashboard/Features/WhatsNewFeatureCard'
+import HomepageShell from '@/components/Homepage/HomepageShell'
+import { whatsNew } from '@/lib/whatsNew'
+import type { NextPageWithLayout } from '@/pages/_app'
+
+const { Title, Paragraph } = Typography
+
+const pageTitle = "What's New | Dotabod"
+const pageDescription =
+  'The latest Dotabod features, commands, and pages — follow along as they ship.'
+const canonicalUrl = 'https://dotabod.com/whats-new'
+
+// Public, indexable changelog so anyone (logged in or not) can follow new releases. Same
+// registry + cards as the dashboard page, rendered read-only (no toggles).
+const WhatsNewPublic: NextPageWithLayout = () => {
+  const entries = [...whatsNew].sort(
+    (a, b) => new Date(b.releaseDate).getTime() - new Date(a.releaseDate).getTime(),
+  )
+
+  return (
+    <>
+      <Head>
+        <title>{pageTitle}</title>
+        <meta name='description' content={pageDescription} />
+        <link rel='canonical' href={canonicalUrl} />
+
+        <meta property='og:type' content='website' />
+        <meta property='og:url' content={canonicalUrl} />
+        <meta property='og:title' content={pageTitle} />
+        <meta property='og:description' content={pageDescription} />
+
+        <meta property='twitter:card' content='summary_large_image' />
+        <meta property='twitter:url' content={canonicalUrl} />
+        <meta property='twitter:title' content={pageTitle} />
+        <meta property='twitter:description' content={pageDescription} />
+      </Head>
+      <Container className='pb-16'>
+        <div className='mx-auto max-w-3xl'>
+          <Title level={1}>What&apos;s new</Title>
+          <Paragraph className='mb-8 text-lg'>
+            The latest Dotabod features, commands, and pages — newest first.{' '}
+            <Link href='/dashboard/whats-new' className='text-purple-400 hover:text-purple-300'>
+              Manage them in your dashboard →
+            </Link>
+          </Paragraph>
+
+          <div className='grid grid-cols-1 gap-6'>
+            {entries.map((entry, i) => (
+              <div id={entry.id} key={entry.id}>
+                <WhatsNewFeatureCard entry={entry} latest={i === 0} readOnly />
+              </div>
+            ))}
+          </div>
+        </div>
+      </Container>
+    </>
+  )
+}
+
+WhatsNewPublic.getLayout = function getLayout(page: ReactElement) {
+  return (
+    <HomepageShell
+      ogImage={{ subtitle: pageDescription, title: "What's New" }}
+      seo={{ canonicalUrl, description: pageDescription, ogType: 'website', title: pageTitle }}
+    >
+      {page}
+    </HomepageShell>
+  )
+}
+
+export default WhatsNewPublic

--- a/src/utils/subscription.ts
+++ b/src/utils/subscription.ts
@@ -130,6 +130,7 @@ export const FEATURE_TIERS: Record<SettingKeys | ChatterSettingKeys, Subscriptio
   commandAPM: SUBSCRIPTION_TIERS.FREE,
   commandAvg: SUBSCRIPTION_TIERS.FREE,
   commandDotabuff: SUBSCRIPTION_TIERS.FREE,
+  commandSet: SUBSCRIPTION_TIERS.FREE,
   commandGM: SUBSCRIPTION_TIERS.PRO,
   commandGPM: SUBSCRIPTION_TIERS.FREE,
   commandHero: SUBSCRIPTION_TIERS.PRO,

--- a/src/utils/subscription.ts
+++ b/src/utils/subscription.ts
@@ -101,6 +101,8 @@ export const FEATURE_TIERS: Record<SettingKeys | ChatterSettingKeys, Subscriptio
   'chatters.neutralItems': SUBSCRIPTION_TIERS.PRO,
   'chatters.dotapatch': SUBSCRIPTION_TIERS.FREE,
   aegis: SUBSCRIPTION_TIERS.PRO,
+  autoOptInNewFeatures: SUBSCRIPTION_TIERS.FREE,
+  cosmeticsAnnounce: SUBSCRIPTION_TIERS.FREE,
   betsInfo: SUBSCRIPTION_TIERS.PRO,
   customMmr: SUBSCRIPTION_TIERS.PRO,
   tellChatNewMMR: SUBSCRIPTION_TIERS.FREE,


### PR DESCRIPTION
## What
A "What's New" changelog surface + consolidation of the dashboard notifications endpoint. Shares entry ids with the backend feature-announcement registry.

- `src/lib/whatsNew.ts` registry → `/dashboard/whats-new` (logged-in, per-feature toggles; + home teaser + Features nav entry) and `/whats-new` (**public, indexable**, read-only; linked from the public nav, desktop + mobile)
- `NewFeaturesCard` slimmed to the `autoOptInNewFeatures` master toggle + a link to What's New
- **Single `/api/notifications`** (replaces `gift-notifications`): returns gift + `NEW_FEATURE` rows; bell renders `NEW_FEATURE`; the gift toast in `DashboardShell` filters to `GIFT_SUBSCRIPTION`
- New settings `autoOptInNewFeatures` + `cosmeticsAnnounce` (defaults, FEATURE_TIERS, zod validation, settingsMetadata)

## Tests
`/api/notifications`, the `whatsNew` registry + `entryToggleChecked`, and the WhatsNew/NewFeatures components. Full suite green: **57 files, 307 tests**; `vp check` clean (425 files). No DB migrations.

## Deploy
Coordinated with the backend feature-announcement PR. **Deploy this (frontend) first or together** — it handles the `NEW_FEATURE` notification type + the consolidated endpoint that the backend then produces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)