### PR TITLE
feat: team smoke alert toggle + What's New entry

### DIFF
--- a/src/__tests__/lib/whatsNew.test.ts
+++ b/src/__tests__/lib/whatsNew.test.ts
@@ -62,6 +62,7 @@ const KNOWN_DEEP_LINK_PATHS = [
   '/dashboard',
   '/dashboard/billing',
   '/dashboard/commands',
+  '/dashboard/features/chat',
   '/dashboard/features/overlay',
   '/dashboard/help',
 ]
@@ -71,6 +72,7 @@ describe('deepLinkLabel', () => {
     expect(deepLinkLabel({ path: '/dashboard' })).toBe('Open dashboard')
     expect(deepLinkLabel({ path: '/dashboard/billing' })).toBe('Open billing')
     expect(deepLinkLabel({ path: '/dashboard/commands' })).toBe('Open commands')
+    expect(deepLinkLabel({ path: '/dashboard/features/chat' })).toBe('Open chat settings')
     expect(deepLinkLabel({ path: '/dashboard/features/overlay' })).toBe('Open overlay settings')
     expect(deepLinkLabel({ path: '/dashboard/help' })).toBe('Open help center')
   })

--- a/src/components/Dashboard/Features/ChatterCard.tsx
+++ b/src/components/Dashboard/Features/ChatterCard.tsx
@@ -302,6 +302,22 @@ export const chatterInfo = {
     ),
     tooltip: 'Whenever your hero has smoke debuff',
   },
+  smokeActivated: {
+    category: CATEGORIES.Event,
+    message: (
+      <span className='inline space-x-2'>
+        <Image
+          width={22}
+          height={22}
+          alt='Shush'
+          className='inline align-middle'
+          src='/images/emotes/Shush.png'
+        />
+        <span>Pudge activated Smoke of Deceit!</span>
+      </span>
+    ),
+    tooltip: "When your team smokes — and calls you out if you weren't in it",
+  },
   tip: {
     category: CATEGORIES.Event,
     message: (

--- a/src/lib/defaultSettings.ts
+++ b/src/lib/defaultSettings.ts
@@ -122,6 +122,9 @@ export const defaultSettings = {
     smoke: {
       enabled: true,
     },
+    smokeActivated: {
+      enabled: true,
+    },
     tip: {
       enabled: true,
     },

--- a/src/lib/settingsMetadata.ts
+++ b/src/lib/settingsMetadata.ts
@@ -255,6 +255,16 @@ export const settingsMetadata: SettingMetadata[] = [
   },
   {
     category: 'chat',
+    description: 'Announce when your team activates Smoke of Deceit, and rib you if you missed it',
+    isNested: true,
+    key: 'chatters.smokeActivated',
+    label: 'Smoke Activated Alert',
+    page: { path: '/dashboard/features/chat', section: 'chatters' },
+    parentKey: 'chatters',
+    searchTerms: ['smoke', 'gank', 'deceit', 'activated', 'team'],
+  },
+  {
+    category: 'chat',
     description: 'Announce Aegis pickup',
     isNested: true,
     key: 'chatters.aegis-pickup',

--- a/src/lib/validations/setting.ts
+++ b/src/lib/validations/setting.ts
@@ -44,6 +44,7 @@ const settingsSchema = {
       roshPickup: z.object({ enabled: z.boolean() }),
       roshanKilled: z.object({ enabled: z.boolean() }),
       smoke: z.object({ enabled: z.boolean() }),
+      smokeActivated: z.object({ enabled: z.boolean() }),
       tip: z.object({ enabled: z.boolean() }),
     })
     .partial(),

--- a/src/lib/whatsNew.ts
+++ b/src/lib/whatsNew.ts
@@ -30,6 +30,21 @@ export interface WhatsNewEntry {
 
 export const whatsNew: WhatsNewEntry[] = [
   {
+    id: 'smoke-activated',
+    title: 'Team smoke alerts',
+    description:
+      'When your team pops Smoke of Deceit, Dotabod posts a single line a few seconds later — naming the hero who smoked if you grouped up, or ribbing you if you got left behind.',
+    releaseDate: '2026-06-12',
+    category: 'chat',
+    tier: 'FREE',
+    deepLink: { path: '/dashboard/features/chat', section: 'chatters' },
+    demo: { chat: 'team smoking without you HAH' },
+    details: [
+      "It triggers on the in-game smoke-activated event, which Dota only sends for your own team, so it never reveals an enemy smoke — and it's separate from the existing Smoke alert, which only fires when your own hero gets the smoke debuff.",
+      "A few seconds after a teammate smokes, Dotabod checks whether your hero actually caught the buff and posts one line: if you grouped up it names the hero who popped it (or a generic line for 8500+ games where heroes are hidden); if you got left behind, it lets chat know you weren't with the team.",
+    ],
+  },
+  {
     id: 'cosmetics',
     title: 'Cosmetic set announcements',
     description:
@@ -295,6 +310,7 @@ const DEEP_LINK_LABELS: Record<string, string> = {
   '/dashboard': 'Open dashboard',
   '/dashboard/billing': 'Open billing',
   '/dashboard/commands': 'Open commands',
+  '/dashboard/features/chat': 'Open chat settings',
   '/dashboard/features/overlay': 'Open overlay settings',
   '/dashboard/help': 'Open help center',
 }

--- a/src/utils/subscription.ts
+++ b/src/utils/subscription.ts
@@ -86,6 +86,7 @@ export const FEATURE_TIERS: Record<SettingKeys | ChatterSettingKeys, Subscriptio
   'chatters.midas': SUBSCRIPTION_TIERS.PRO,
   'chatters.pause': SUBSCRIPTION_TIERS.FREE,
   'chatters.smoke': SUBSCRIPTION_TIERS.FREE,
+  'chatters.smokeActivated': SUBSCRIPTION_TIERS.FREE,
   'chatters.passiveDeath': SUBSCRIPTION_TIERS.PRO,
   'chatters.roshPickup': SUBSCRIPTION_TIERS.PRO,
   'chatters.roshDeny': SUBSCRIPTION_TIERS.PRO,


### PR DESCRIPTION
## What

Adds the dashboard surface for the new **team smoke alert** chatter landing in the backend (dotabod/backend#613).

## Changes

- `chatters.smokeActivated` toggle (default on, FREE) wired through `defaultSettings`, the zod validation schema, and the `FEATURE_TIERS` map.
- `ChatterCard` entry (preview + tooltip) and `settingsMetadata` entry, so it renders on the chat features page and is searchable.
- A **"Team smoke alerts"** What's New entry, plus its `/dashboard/features/chat` deep-link label (with matching coverage in `whatsNew.test.ts`).

## Behavior (driven by the backend)

The single toggle controls one message per team smoke, ~3s after activation: names the hero who smoked if you grouped up, or `team smoking without you HAH` if you got left behind.

## Test plan

- `whatsNew.test.ts` (registry shape, unique ids, known deep-link labels) passing.
- Full suite green via pre-commit hook: **336 passed**; `vp check` + typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
