### PR TITLE
chore(deps): batch dependabot into weekly grouped PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,16 +1,37 @@
 version: 2
+
+# Dependabot opened one PR per dependency, which generated a large share of the
+# repo's Discord notification volume. Everything below is batched into a single
+# weekly PR per ecosystem instead. `groups` needs both `applies-to` values:
+# security updates are raised regardless of schedule and group separately from
+# version updates.
 updates:
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:
-      interval: 'daily'
+      interval: 'weekly'
+    groups:
+      actions:
+        applies-to: version-updates
+        patterns: ['*']
+      actions-security:
+        applies-to: security-updates
+        patterns: ['*']
+
   - package-ecosystem: 'npm'
     directory: '/'
     schedule:
-      interval: 'daily'
+      interval: 'weekly'
     # Wait past pnpm's minimumReleaseAge (default 1d) before bumping, so the
     # lockfile Dependabot commits doesn't trip the supply-chain policy in CI
     # or Vercel. Bigger window for majors out of general caution.
     cooldown:
       default-days: 2
       semver-major-days: 7
+    groups:
+      npm:
+        applies-to: version-updates
+        patterns: ['*']
+      npm-security:
+        applies-to: security-updates
+        patterns: ['*']


### PR DESCRIPTION
Dependabot opened one PR per dependency. Across both repos that produced ~200 Discord notifications over three years, which is what prompted this.

Both ecosystems are now batched into a single weekly PR each. Security updates get their own group because GitHub raises them regardless of schedule or config.

The existing pnpm `minimumReleaseAge` cooldown block is preserved unchanged.

Matching change on the backend: dotabod/backend@8737308c