### PR TITLE
fix: handle missing overlay users gracefully

### DIFF
--- a/src/__tests__/pages/api/diagnostics-overlay-page.test.ts
+++ b/src/__tests__/pages/api/diagnostics-overlay-page.test.ts
@@ -1,4 +1,5 @@
-import type { NextApiHandler } from 'next'
+import { Prisma } from '@prisma/client'
+import type { NextApiHandler, NextApiRequest, NextApiResponse } from 'next'
 import { createMocks } from 'node-mocks-http'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -39,5 +40,35 @@ describe('overlay page diagnostic beacon', () => {
     await handler(req, res)
     expect(res.statusCode).toBe(422)
     expect(prisma.setting.upsert).not.toHaveBeenCalled()
+  })
+
+  it('returns not found when the overlay user no longer exists', async () => {
+    vi.mocked(prisma.setting).upsert.mockRejectedValue(
+      new Prisma.PrismaClientKnownRequestError('Foreign key constraint failed', {
+        clientVersion: 'test',
+        code: 'P2003',
+      }),
+    )
+    const { req, res } = createMocks<NextApiRequest, NextApiResponse>({
+      body: { userId: '00000000-0000-4000-8000-000000000000' },
+      method: 'POST',
+    })
+
+    await handler(req, res)
+
+    expect(res.statusCode).toBe(404)
+  })
+
+  it('rethrows unrelated database failures', async () => {
+    const outage = new Prisma.PrismaClientUnknownRequestError('Database unavailable', {
+      clientVersion: 'test',
+    })
+    vi.mocked(prisma.setting).upsert.mockRejectedValue(outage)
+    const { req, res } = createMocks<NextApiRequest, NextApiResponse>({
+      body: { userId: '00000000-0000-4000-8000-000000000000' },
+      method: 'POST',
+    })
+
+    await expect(handler(req, res)).rejects.toBe(outage)
   })
 })

--- a/src/pages/api/diagnostics/overlay-page.ts
+++ b/src/pages/api/diagnostics/overlay-page.ts
@@ -1,3 +1,4 @@
+import { Prisma } from '@prisma/client'
 import type { NextApiRequest, NextApiResponse } from 'next'
 import { z } from 'zod'
 
@@ -15,11 +16,19 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
   }
 
   const { userId } = parsed.data
-  await prisma.setting.upsert({
-    create: { key: SETUP_SIGNAL_KEYS.overlayPageLastSeen, userId, value: true },
-    update: { updatedAt: new Date(), value: true },
-    where: { key_userId: { key: SETUP_SIGNAL_KEYS.overlayPageLastSeen, userId } },
-  })
+  try {
+    await prisma.setting.upsert({
+      create: { key: SETUP_SIGNAL_KEYS.overlayPageLastSeen, userId, value: true },
+      update: { updatedAt: new Date(), value: true },
+      where: { key_userId: { key: SETUP_SIGNAL_KEYS.overlayPageLastSeen, userId } },
+    })
+  } catch (error) {
+    if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2003') {
+      res.status(404).json({ message: 'User not found' })
+      return
+    }
+    throw error
+  }
   return res.status(204).end()
 }
 


### PR DESCRIPTION
## Summary

- Return 404 when the overlay diagnostic references a deleted user.
- Preserve propagation of unrelated database errors.
- Add regression coverage for both cases.

## Testing

- Not run (not provided).