### PR TITLE
Add GitHub-hosted verification for Dotabod profile UI

### DIFF
--- a/.agents/skills/verify-dotabod/SKILL.md
+++ b/.agents/skills/verify-dotabod/SKILL.md
@@ -1,0 +1,107 @@
+---
+name: verify-dotabod
+description: Verify Dotabod's Next.js web frontend through its real public streamer-profile UI on GitHub-hosted runners. Use when changes affect the profile overview, match history, hero win rates, cosmetic collection, hero detail, responsive layout, navigation, or scoped accessibility.
+---
+
+# Verify Dotabod
+
+Drive Dotabod as a user through a production Next.js bundle, isolated Postgres data, and headless Chromium. The primary surface is the web UI. The authenticated dashboard and OBS overlay are secondary surfaces and are not yet covered by this feature map.
+
+Read [features/README.md](features/README.md) before choosing a route. Also read the shared [frontend verification skill](../dotabod-frontend-verification/SKILL.md) and its [harness reference](../dotabod-frontend-verification/references/verification-harness.md) before changing infrastructure or lifecycle behavior.
+
+## Safety boundary
+
+- Never run the build, test suite, production server, browser harness, Prisma generation, or database setup on this production-shared host.
+- End-to-end verification runs only in the GitHub-hosted workflow at `.github/workflows/verify-dotabod.yml`.
+- Dispatching a workflow and pushing a branch require user authorization. Do not commit, push, or dispatch merely because this skill was selected.
+- The browser workflow runs for matching pull-request paths and supports manual dispatch. It complements, but does not replace, the repository's required `CI` workflow.
+- Never point the fixture seed at an existing or non-local database. Never drive a server or browser that this run did not start.
+
+## Launch
+
+The branch containing the code and verification files must already be pushed. Dispatch the manual workflow from the repository root:
+
+```bash
+gh workflow run verify-dotabod.yml --ref "$(git branch --show-current)"
+```
+
+Find and watch the run:
+
+```bash
+gh run list --workflow verify-dotabod.yml --branch "$(git branch --show-current)" --event workflow_dispatch --limit 3
+gh run watch <run-id> --exit-status
+```
+
+The GitHub job installs dependencies and invokes [scripts/run-profile-verification.sh](scripts/run-profile-verification.sh). The underlying harness reports these readiness lines before driving the UI:
+
+```text
+[frontend-verification] Next production server ready at http://127.0.0.1:3100
+[frontend-verification] Chromium CDP ready at http://127.0.0.1:9223/json/version
+```
+
+The harness owns launch and teardown as one operation. It stops only its child process groups and disposable Postgres cluster in a `finally` path, including after a failed verification command.
+
+## Doctor
+
+Inside a GitHub-hosted runner, run this read-only prerequisite check before launching:
+
+```bash
+.agents/skills/verify-dotabod/scripts/run-profile-verification.sh --doctor
+```
+
+Doctor refuses non-GitHub-hosted execution, confirms Linux, Node, pnpm, Git, Chromium, PostgreSQL tools, the repository revision, and the required adapter files. During launch, the shared harness additionally requires its app, CDP, and Postgres ports to be free, waits for the production URL and CDP endpoint, and the adapter requires a real Chromium page target. Treat any failed gate as an unhealthy instance; inspect the named log instead of bypassing it.
+
+## Drive
+
+The workflow runs this exact helper:
+
+```bash
+.agents/skills/verify-dotabod/scripts/run-profile-verification.sh
+```
+
+It seeds `maxid1337` and hero `2` into disposable local Postgres, then drives these user routes at desktop `1440x1000` and mobile `390x844`:
+
+- `/maxid1337`
+- `/maxid1337/matches`
+- `/maxid1337/matches?view=heroes`
+- `/maxid1337/set`
+- `/maxid1337/set/2`
+
+The adapter uses stable handles from the product: `[data-testid="profile-match-overview"]`, `nav[aria-label="Profile sections"]`, `nav[aria-label="Match history view"]`, `nav[aria-label="Match history period"]`, `table[aria-label="Most played heroes"]`, `table[aria-label="Latest matches"]`, and `table[aria-label="Recent matches"]`. It clicks real links, sends real Tab key events for `:focus-visible`, and never sets application state through test-only endpoints.
+
+Use the matching feature file for the expected visible state and artifact names. A pass on one route does not prove another mapped route.
+
+## Evidence
+
+The workflow uploads the `dotabod-profile-verification` artifact. Download it after the run:
+
+```bash
+gh run download <run-id> --name dotabod-profile-verification --dir artifacts/verify-dotabod/github-run-<run-id>
+```
+
+Require all of the following:
+
+- `frontend-verification-report.json` has `"status": "passed"`.
+- `profile-navigation-audit.json` records both viewports, route assertions, the keyboard-focus result, the navigation journey, and zero scoped WCAG 2.1 A/AA violations.
+- Ten screenshots exist: profile overview, match history, hero win rates, collection, and hero detail at desktop and mobile sizes.
+- The action and resulting state are both present in the audit. A final screenshot alone is insufficient.
+- A human or image-capable agent inspects every relevant screenshot for clipping, overlap, weak hierarchy, broken responsive layout, and unexpected third-party UI.
+- For mutations, verify a second user-facing read of the stored result. The current mapped run is read-only after its disposable fixture seed.
+
+Mocks are acceptable only at an existing production boundary. This workflow uses safe dummy credentials, an isolated local database, and public page props for the fixture; it does not mutate production. Report each skipped or unreachable entry point separately rather than treating a nearby route as equivalent proof.
+
+## Cleanup
+
+Do not kill processes by name. The shared harness tracks the exact process groups it starts, stops its own Next server, Chromium, and Postgres, restores only the known generated `next-env.d.ts` route-import change, and removes only its explicit temporary directories.
+
+The cleanup intentionally preserves `artifacts/verify-dotabod/profile-navigation/`, and the workflow uploads that directory even when the verification step fails. After a failure, inspect the report and logs before rerunning. A cancelled GitHub-hosted job is isolated by destruction of its runner; do not attempt cleanup against another machine.
+
+## Helpers
+
+- [scripts/run-profile-verification.sh](scripts/run-profile-verification.sh): guarded entry point for doctor and the complete mapped browser pass. Invoke it with `--doctor` or with no arguments.
+- [shared harness](../dotabod-frontend-verification/scripts/run-frontend-verification.mjs): owns ports, Postgres, generation, build, Next, Chromium, axe, reports, and cleanup. Do not reproduce its lifecycle commands.
+- [fixture seed](../dotabod-profile-nav-workflow/scripts/seed-profile-fixture.mjs): fetches public profile props and writes only to a localhost database.
+- [browser adapter](../dotabod-profile-nav-workflow/scripts/audit-profile-navigation.mjs): captures screenshots and the machine-readable route audit.
+- `.github/workflows/verify-dotabod.yml`: path-scoped pull-request check, manual launcher, and artifact uploader.
+
+Keep this map current with `$maintain-verification-skill` when routes, handles, fixture requirements, or proof standards change.

--- a/.agents/skills/verify-dotabod/agents/openai.yaml
+++ b/.agents/skills/verify-dotabod/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: 'Verify Dotabod'
+  short_description: 'Verify public Dotabod profile UI on GitHub runners'
+  default_prompt: 'Use $verify-dotabod to run or interpret the GitHub-hosted production browser verification for this Dotabod public-profile change.'

--- a/.agents/skills/verify-dotabod/features/README.md
+++ b/.agents/skills/verify-dotabod/features/README.md
@@ -1,0 +1,40 @@
+# Dotabod verification map
+
+This directory is the maintained source for verifying Dotabod's public streamer-profile experience. Read this index before driving the app, then use every feature file affected by the change.
+
+## Baseline preconditions
+
+- Run only through `.github/workflows/verify-dotabod.yml` on a GitHub-hosted Linux runner.
+- The branch under test is pushed and contains the same revision the workflow checks out.
+- The standard repository `CI` workflow passes separately before PR readiness.
+- The runner can reach `https://dotabod.com` to read the public `maxid1337` collection fixture.
+- The harness owns free localhost ports `3100`, `9223`, and `55432`, a disposable Postgres cluster, a disposable Chromium profile, and a disposable axe installation.
+- The fixture user is `maxid1337`; the detail route uses hero ID `2`.
+- Never drive an existing server, browser, database, or user profile.
+
+## Driving conventions
+
+- Matching pull requests run the workflow automatically. Dispatch it manually only after the user has authorized the external action.
+- The workflow runs `.agents/skills/verify-dotabod/scripts/run-profile-verification.sh`; do not recreate infrastructure commands in a feature recipe.
+- Start with the direct route named in the feature file, then exercise its listed links or controls.
+- Prefer accessible names, roles, test IDs, and route paths over coordinates or DOM position.
+- Treat desktop and mobile as separate entry points. A pass at one viewport does not prove the other.
+- The adapter covers all mapped routes in one isolated run. Report results per feature rather than collapsing them into one generic pass.
+
+## Proof and skip reporting
+
+- Capture the user action and the resulting state, not only a final screen.
+- Inspect `profile-navigation-audit.json` and `frontend-verification-report.json` before screenshots.
+- UI proof includes the matching desktop and mobile screenshots with Dotabod identity and route content visible.
+- Navigation proof includes the requested path and the correct `aria-current="page"` state.
+- Accessibility proof is limited to the exact axe root recorded by the adapter; do not claim a full-page audit when only a navigation region was scanned.
+- Record the workflow run ID and commit SHA with the evidence.
+- Report an unreachable route with the workflow log and unmet precondition. Do not substitute a production screenshot or another route.
+- Preserve downloaded artifacts after cleanup.
+
+## Features
+
+- [Streamer profile overview](./streamer-profile-overview.md) covers the compact hero and match summaries and their links to full history views.
+- [Match history](./match-history.md) covers match rows, hero win rates, periods, pagination, section navigation, and keyboard focus.
+- [Cosmetic collection](./cosmetic-collection.md) covers the public collection route, hero entry points, and its active profile section.
+- [Hero cosmetic detail](./hero-cosmetic-detail.md) covers an individual loadout, sibling navigation, collection return path, and active profile section.

--- a/.agents/skills/verify-dotabod/features/cosmetic-collection.md
+++ b/.agents/skills/verify-dotabod/features/cosmetic-collection.md
@@ -1,0 +1,40 @@
+# Cosmetic collection
+
+The cosmetic collection lets a viewer browse the heroes and equipped sets captured from a streamer's games, open an individual hero loadout, and move back to match history.
+
+## Sub-features
+
+- `collection-route` renders the public collection at `/maxid1337/set`.
+- `collection-current` marks `Cosmetic collection` as the single current profile section.
+- `collection-heroes` exposes seeded hero cards and a `View the full set` entry point.
+- `collection-to-history` navigates to `/maxid1337/matches` through the shared profile rail.
+- `collection-responsive` keeps the profile rail compact and the document free of horizontal overflow.
+
+## How to get to it (user POV)
+
+- Visit `/maxid1337/set` directly.
+- From match history, choose `Cosmetic collection` in `Profile sections`.
+- Choose a hero card or `View the full set` to open that hero's cosmetic detail.
+- Choose `Match history` to return to `/maxid1337/matches`.
+
+## Driving it with Dotabod frontend harness
+
+Preconditions:
+
+- The branch is pushed and workflow dispatch is authorized.
+- The GitHub-hosted doctor passes.
+- The public `maxid1337` collection has at least one card and hero `2` has a loadout; the seed writes those values only to disposable localhost Postgres.
+
+- **Run.** Dispatch `gh workflow run verify-dotabod.yml --ref "$(git branch --show-current)"`. The adapter visits `/maxid1337/set` at desktop and mobile sizes.
+- **Check current state.** `nav[aria-label="Profile sections"]` has exactly one current link, labeled `Cosmetic collection`, with href `/maxid1337/set`.
+- **Check the rail.** Both section links use 14px Inter text with at least 4.5:1 contrast; only the current link has a visible bottom border. The rail is at most 56px tall and allows no vertical scrolling.
+- **Check navigation.** The recorded journey clicks `Cosmetic collection` from match history and observes `/maxid1337/set` with the collection label current. It later clicks `Match history` and observes the inverse state.
+- **Inspect the collection.** Confirm the screenshot shows the `Cosmetic collection` heading, populated hero content, and an entry point into a full set. This visual inspection is required because the shared adapter's collection assertions focus on navigation and layout invariants.
+- **Proof.** Inspect `collection-desktop.png`, `collection-mobile.png`, the `/maxid1337/set` audit entries, and `navigationJourney.toCollection` in `profile-navigation-audit.json`.
+
+## Gotchas
+
+- Axe is scoped to `nav[aria-label="Profile sections"]` on the collection route. Do not report the full collection page as axe-clean.
+- Hero cards come from public page props fetched during seeding, so their names and counts can change independently of this branch.
+- The adapter proves the route and shared navigation automatically; populated collection content still requires screenshot inspection.
+- Third-party HubSpot UI is hidden only inside screenshot automation and must not be removed from product code.

--- a/.agents/skills/verify-dotabod/features/hero-cosmetic-detail.md
+++ b/.agents/skills/verify-dotabod/features/hero-cosmetic-detail.md
@@ -1,0 +1,40 @@
+# Hero cosmetic detail
+
+Hero cosmetic detail shows one captured Dota hero loadout, links back to the collection, and lets a viewer move to adjacent heroes without losing the collection's active profile section.
+
+## Sub-features
+
+- `detail-route` renders hero `2` at `/maxid1337/set/2`.
+- `detail-current` keeps `Cosmetic collection` as the single current profile section.
+- `detail-siblings` exposes at least one previous or next hero link.
+- `detail-back` links back to `/maxid1337/set` through the breadcrumb, position link, and page footer.
+- `detail-responsive` preserves the loadout and navigation at desktop and mobile sizes without document overflow.
+
+## How to get to it (user POV)
+
+- Visit `/maxid1337/set/2` directly.
+- From `/maxid1337/set`, choose the hero `2` card or its `View the full set` link.
+- Choose the named previous or next hero link to move through the binder.
+- Choose `Collection`, the position indicator, or `Back to the collection` to return to `/maxid1337/set`.
+
+## Driving it with Dotabod frontend harness
+
+Preconditions:
+
+- The branch is pushed and workflow dispatch is authorized.
+- The GitHub-hosted doctor passes.
+- The public fixture for `maxid1337` includes hero ID `2`, its item list, and at least one sibling loadout.
+
+- **Run.** Dispatch `gh workflow run verify-dotabod.yml --ref "$(git branch --show-current)"`. The adapter visits `/maxid1337/set/2` at desktop and mobile sizes.
+- **Check current state.** `nav[aria-label="Profile sections"]` exposes both profile routes and marks only `Cosmetic collection` with `aria-current="page"`.
+- **Check sibling navigation.** The adapter finds at least one link whose href starts with `/maxid1337/set/` and ends in an integer hero ID. Inspect the screenshot to confirm the adjacent hero name and arrow are visible.
+- **Check collection return.** Inspect the breadcrumb `Collection`, the centered position link, and `Back to the collection`; each should resolve to `/maxid1337/set`.
+- **Inspect the loadout.** Confirm the screenshot shows the hero heading, equipped-cosmetic count, item grid, and any rarity summary or spotlight produced by the seeded loadout.
+- **Proof.** Inspect `hero-detail-desktop.png`, `hero-detail-mobile.png`, and the `/maxid1337/set/2` entries in `profile-navigation-audit.json`. The route must have a sibling link, correct current section, no horizontal document overflow, and zero axe violations in the scoped profile rail.
+
+## Gotchas
+
+- The page supports left and right arrow-key navigation in product code, but the current adapter does not exercise those keys. Do not claim that behavior as verified.
+- Axe is scoped to `nav[aria-label="Profile sections"]`, not the loadout grid or market links.
+- The fixture's item images and marketability come from public page props and can change independently of the branch.
+- A sibling-link count proves an entry point exists; screenshot inspection is still required to catch clipping or an unclear direction label.

--- a/.agents/skills/verify-dotabod/features/match-history.md
+++ b/.agents/skills/verify-dotabod/features/match-history.md
@@ -1,0 +1,43 @@
+# Match history
+
+Match history lets a viewer switch between recent match rows and aggregated hero win rates, change the time period, paginate to older matches, and move to the streamer's cosmetic collection.
+
+## Sub-features
+
+- `history-matches` shows 20 recent seeded match rows and an older-matches link.
+- `history-heroes` switches to the hero-win-rates view without rendering the match table.
+- `history-periods` preserves `7 days`, `30 days`, and `All time` period controls.
+- `history-sections` moves between `Match history` and `Cosmetic collection` with exactly one current section.
+- `history-keyboard` gives the profile-section links a visible focus indicator reached through real Tab input.
+- `history-responsive` preserves readable navigation without document overflow at both mapped viewports.
+
+## How to get to it (user POV)
+
+- Visit `/maxid1337/matches` directly or choose `View all matches` from `/maxid1337`.
+- Choose `Hero win rates` to reach `/maxid1337/matches?view=heroes`.
+- Choose `Matches` to return to `/maxid1337/matches`.
+- Choose `Cosmetic collection` in `Profile sections` to reach `/maxid1337/set`.
+
+## Driving it with Dotabod frontend harness
+
+Preconditions:
+
+- The branch is pushed and workflow dispatch is authorized.
+- The GitHub-hosted doctor passes and the fixture seed creates 25 matches for `maxid1337`.
+- The adapter can reach a Chromium page through `FRONTEND_CDP_URL`.
+
+- **Run.** Dispatch `gh workflow run verify-dotabod.yml --ref "$(git branch --show-current)"`. The adapter visits the matches and hero-win-rate routes at desktop and mobile sizes.
+- **Inspect matches.** On `/maxid1337/matches`, `nav[aria-label="Match history view"]` marks `Matches` current, `table[aria-label="Recent matches"]` contains 20 rows, and `View older matches` is visible.
+- **Inspect hero rates.** Choose `Hero win rates`. The URL becomes `/maxid1337/matches?view=heroes`, `Hero win rates` becomes current, `#hero-win-rates-heading` exists, and the recent-match table is absent.
+- **Return to matches.** Choose `Matches`. The query string clears, `Matches` becomes current, and the recent-match table returns.
+- **Check periods.** `nav[aria-label="Match history period"]` contains `7 days`, `30 days`, and `All time` in both views.
+- **Check section navigation.** `nav[aria-label="Profile sections"]` exposes `/maxid1337/matches` and `/maxid1337/set`; exactly one link has `aria-current="page"`. The adapter clicks both directions and records the resulting path and current label.
+- **Check keyboard focus.** On the mobile viewport, the adapter sends real Tab events until focus reaches `Profile sections`, then requires `:focus-visible` and an outline at least 2px wide.
+- **Proof.** Inspect `match-history-desktop.png`, `match-history-mobile.png`, `hero-win-rates-desktop.png`, `hero-win-rates-mobile.png`, and the matching `audits`, `keyboardFocus`, and `navigationJourney` values in `profile-navigation-audit.json`.
+
+## Gotchas
+
+- The match-history and profile-section rails are independent. Do not confuse `Matches` with `Match history` when asserting current state.
+- The initial table intentionally contains 20 of the 25 seeded matches; the remainder prove the older-matches entry point.
+- Calling `element.focus()` is not valid focus proof. The adapter uses CDP key events so `:focus-visible` behaves like keyboard input.
+- Axe is scoped to `[data-testid="match-history-page"]` on the two history views, not the entire document.

--- a/.agents/skills/verify-dotabod/features/streamer-profile-overview.md
+++ b/.agents/skills/verify-dotabod/features/streamer-profile-overview.md
@@ -1,0 +1,38 @@
+# Streamer profile overview
+
+The streamer profile gives a viewer a compact summary of the streamer's most-played heroes and latest matches, with user-facing links into the complete match and hero-win-rate views.
+
+## Sub-features
+
+- `overview-heroes` renders one to five rows in `Most played heroes`.
+- `overview-matches` renders one to five rows in `Latest matches`, newest first.
+- `overview-all-matches` links to the complete match-history route.
+- `overview-hero-rates` links to the hero-win-rates view.
+- `overview-responsive` avoids horizontal document overflow at desktop and mobile sizes.
+
+## How to get to it (user POV)
+
+- Visit `/maxid1337` directly.
+- In the overview, choose `View all matches` to reach `/maxid1337/matches`.
+- In the overview, choose `View all hero win rates` to reach `/maxid1337/matches?view=heroes`.
+
+## Driving it with Dotabod frontend harness
+
+Preconditions:
+
+- The branch is pushed and workflow dispatch is authorized.
+- `.agents/skills/verify-dotabod/scripts/run-profile-verification.sh --doctor` passes in the GitHub-hosted runner.
+- The public fixture contains at least one cosmetic card and the seed creates 25 representative matches.
+
+- **Run.** Dispatch `gh workflow run verify-dotabod.yml --ref "$(git branch --show-current)"`. The helper launches the isolated production bundle and visits `/maxid1337` at both mapped viewports.
+- **Find the overview.** The adapter waits for `[data-testid="profile-match-overview"]`. It finds semantic tables named `Most played heroes` and `Latest matches` with one to five rows each.
+- **Check destinations.** The overview exposes `View all matches` with href `/maxid1337/matches` and `View all hero win rates` with href `/maxid1337/matches?view=heroes`.
+- **Check ordering.** The first latest-match link points to `https://www.opendota.com/matches/8964010929`, the newest seeded match.
+- **Proof.** Inspect `profile-overview-desktop.png`, `profile-overview-mobile.png`, and the `/maxid1337` entries under `profileAudits` in `profile-navigation-audit.json`. Both routes must have zero scoped axe violations and no horizontal document overflow.
+
+## Gotchas
+
+- The screenshots are clipped to the overview component, not the whole profile page.
+- The overview route does not render the shared `Profile sections` rail; prove its two explicit history links instead.
+- The external OpenDota destination is asserted as an href. The adapter does not navigate away from Dotabod.
+- Public fixture changes can make seeding fail before the local app starts; report that as a fixture precondition failure, not a product regression.

--- a/.agents/skills/verify-dotabod/scripts/run-profile-verification.sh
+++ b/.agents/skills/verify-dotabod/scripts/run-profile-verification.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+verification_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)"
+cd "$verification_root"
+
+doctor() {
+  if [[ "${RUNNER_ENVIRONMENT:-}" != 'github-hosted' ]]; then
+    echo 'verify-dotabod may run only on a GitHub-hosted runner' >&2
+    return 1
+  fi
+
+  [[ "$(uname -s)" == 'Linux' ]] || {
+    echo 'verify-dotabod requires Linux' >&2
+    return 1
+  }
+
+  for command_name in bash git node pnpm; do
+    command -v "$command_name" >/dev/null || {
+      echo "missing required command: $command_name" >&2
+      return 1
+    }
+  done
+
+  local chromium_bin="${CHROMIUM_BIN:-}"
+  if [[ -z "$chromium_bin" ]]; then
+    chromium_bin="$(command -v chromium || command -v chromium-browser || command -v google-chrome-stable || command -v google-chrome || true)"
+  fi
+  [[ -n "$chromium_bin" && -x "$chromium_bin" ]] || {
+    echo 'missing Chromium; set CHROMIUM_BIN to an executable browser' >&2
+    return 1
+  }
+  export CHROMIUM_BIN="$chromium_bin"
+
+  local postgres_bin
+  postgres_bin="$(find /usr/lib/postgresql -type f -name initdb -perm -u+x -print -quit 2>/dev/null || true)"
+  [[ -n "$postgres_bin" ]] || {
+    echo 'missing PostgreSQL initdb under /usr/lib/postgresql' >&2
+    return 1
+  }
+
+  local required_file
+  for required_file in \
+    .agents/skills/dotabod-frontend-verification/scripts/run-frontend-verification.mjs \
+    .agents/skills/dotabod-profile-nav-workflow/scripts/seed-profile-fixture.mjs \
+    .agents/skills/dotabod-profile-nav-workflow/scripts/audit-profile-navigation.mjs; do
+    [[ -f "$required_file" ]] || {
+      echo "missing required adapter file: $required_file" >&2
+      return 1
+    }
+  done
+
+  git rev-parse --verify HEAD >/dev/null
+  git diff --check
+  echo "verify-dotabod doctor passed for $(git rev-parse --short HEAD)"
+  echo "Chromium: $CHROMIUM_BIN"
+  echo "PostgreSQL: $postgres_bin"
+}
+
+if [[ "${1:-}" == '--doctor' ]]; then
+  doctor
+  exit 0
+fi
+
+if [[ $# -ne 0 ]]; then
+  echo 'usage: run-profile-verification.sh [--doctor]' >&2
+  exit 2
+fi
+
+doctor
+
+exec node .agents/skills/dotabod-frontend-verification/scripts/run-frontend-verification.mjs \
+  --output-dir artifacts/verify-dotabod/profile-navigation \
+  --check-command 'pnpm exec vitest run src/__tests__/pages/match-history.test.tsx src/__tests__/pages/collection-navigation.test.tsx src/__tests__/pages/profile-match-overview.test.tsx' \
+  --check-command 'pnpm check' \
+  --check-command 'git diff --check' \
+  --seed-command 'node .agents/skills/dotabod-profile-nav-workflow/scripts/seed-profile-fixture.mjs --username maxid1337 --hero-id 2' \
+  --verify-command 'node .agents/skills/dotabod-profile-nav-workflow/scripts/audit-profile-navigation.mjs --base-url "$FRONTEND_BASE_URL" --cdp-url "$FRONTEND_CDP_URL" --username maxid1337 --hero-id 2 --axe-script "$FRONTEND_AXE_SCRIPT" --output-dir "$FRONTEND_OUTPUT_DIR"'

--- a/.github/workflows/verify-dotabod.yml
+++ b/.github/workflows/verify-dotabod.yml
@@ -1,0 +1,53 @@
+name: Verify Dotabod
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - '.agents/skills/verify-dotabod/**'
+      - '.agents/skills/dotabod-frontend-verification/**'
+      - '.agents/skills/dotabod-profile-nav-workflow/**'
+      - '.github/workflows/verify-dotabod.yml'
+      - 'prisma/**'
+      - 'prisma-mongo/**'
+      - 'src/components/CosmeticSet/**'
+      - 'src/components/profile-match-overview.tsx'
+      - 'src/components/profile-section-nav.tsx'
+      - 'src/lib/match-history.ts'
+      - 'src/pages/[username].tsx'
+      - 'src/pages/[username]/matches.tsx'
+      - 'src/pages/[username]/set.tsx'
+      - 'src/pages/[username]/set/[hero-id].tsx'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: verify-dotabod-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  profile-ui:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v7
+      - uses: pnpm/action-setup@v6
+        with:
+          version: 11.2.2
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 24
+          cache: pnpm
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Verify public profile UI
+        run: .agents/skills/verify-dotabod/scripts/run-profile-verification.sh
+      - name: Upload verification evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: dotabod-profile-verification
+          path: artifacts/verify-dotabod/profile-navigation
+          if-no-files-found: warn
+          retention-days: 14

--- a/.github/workflows/verify-dotabod.yml
+++ b/.github/workflows/verify-dotabod.yml
@@ -14,10 +14,10 @@ on:
       - 'src/components/profile-match-overview.tsx'
       - 'src/components/profile-section-nav.tsx'
       - 'src/lib/match-history.ts'
-      - 'src/pages/[username].tsx'
-      - 'src/pages/[username]/matches.tsx'
-      - 'src/pages/[username]/set.tsx'
-      - 'src/pages/[username]/set/[hero-id].tsx'
+      - 'src/pages/\[username\].tsx'
+      - 'src/pages/\[username\]/matches.tsx'
+      - 'src/pages/\[username\]/set.tsx'
+      - 'src/pages/\[username\]/set/\[hero-id\].tsx'
 
 permissions:
   contents: read

--- a/.gitignore
+++ b/.gitignore
@@ -60,5 +60,7 @@ public/install.ps1
 !.agents/skills/dotabod-frontend-verification/**
 !.agents/skills/dotabod-profile-nav-workflow/
 !.agents/skills/dotabod-profile-nav-workflow/**
+!.agents/skills/verify-dotabod/
+!.agents/skills/verify-dotabod/**
 .playwright-mcp/
 artifacts/


### PR DESCRIPTION
## Summary

- add a project-local `verify-dotabod` skill with launch, doctor, evidence, and cleanup guidance
- map the streamer overview, match history, hero win rates, cosmetic collection, and hero-detail user paths
- add a guarded runner that composes the existing isolated Postgres, production Next.js, Chromium, and axe harnesses
- add a path-scoped pull-request workflow with manual dispatch and persistent verification artifacts