### PR TITLE
Harden subscription checkout and HubSpot status sync

### DIFF
--- a/scripts/backfill-hubspot-contacts.ts
+++ b/scripts/backfill-hubspot-contacts.ts
@@ -2,7 +2,7 @@
 
 /**
  * One-time backfill: sync every Dotabod user with an email into HubSpot as a
- * CRM contact, so a Marketing Email blast can reach the whole user base.
+ * CRM contact so contact coverage and subscription labels can be reconciled.
  *
  * Today contacts are only synced when a logged-in user loads a page with the
  * HubSpot chat widget (see src/pages/api/hubspot/visitor-token.ts), so coverage
@@ -10,8 +10,8 @@
  * sets email, twitch_username, and dotabod_subscription via syncHubSpotContact.
  *
  * Idempotent: syncHubSpotContact PATCHes by email and creates on 404, so
- * re-running is safe. Errors per-contact are swallowed (Sentry) by the helper,
- * so the run never aborts mid-way; we keep our own success/skip counters.
+ * re-running is safe. Errors per-contact are reported to Sentry and returned
+ * to this script so its success and failure counters remain accurate.
  *
  * Usage:
  *   doppler run -- pnpm dlx tsx scripts/backfill-hubspot-contacts.ts [--limit N]
@@ -61,12 +61,16 @@ const syncUser = async function syncUser(user: {
     subscription = undefined
   }
   try {
-    await syncHubSpotContact(token, {
+    const didSync = await syncHubSpotContact(token, {
       email: user.email,
       subscription,
       username: user.displayName ?? '',
     })
-    synced += 1
+    if (didSync) {
+      synced += 1
+    } else {
+      failed += 1
+    }
   } catch {
     failed += 1
   }
@@ -82,7 +86,8 @@ const runPool = async function runPool(
   let cursor = 0
   const worker = async function worker() {
     while (cursor < users.length) {
-      const user = users[(cursor += 1)]
+      const user = users[cursor]
+      cursor += 1
       await syncUser(user)
     }
   }

--- a/src/__tests__/lib/hubspot.test.ts
+++ b/src/__tests__/lib/hubspot.test.ts
@@ -45,6 +45,15 @@ describe('lib/hubspot', () => {
       expect(subscriptionToValue({ status: 'PAST_DUE', tier: 'PRO' })).toBe('pro_past_due')
       expect(subscriptionToValue({ status: 'ACTIVE', tier: 'PRO' })).toBe('pro')
     })
+
+    it('maps inactive and incomplete Pro rows to free', async () => {
+      const { subscriptionToValue } = await load()
+      expect(
+        subscriptionToValue({ status: 'CANCELED', tier: 'PRO', transactionType: 'LIFETIME' }),
+      ).toBe('free')
+      expect(subscriptionToValue({ status: 'INCOMPLETE', tier: 'PRO' })).toBe('free')
+      expect(subscriptionToValue({ tier: 'PRO' })).toBe('free')
+    })
   })
 
   describe('syncHubSpotContact', () => {
@@ -55,7 +64,13 @@ describe('lib/hubspot', () => {
       const { fetchMock, syncHubSpotContact } = await load()
       fetchMock.mockResolvedValue(res())
 
-      await syncHubSpotContact('tok', { email: 'a@b.com', subscription: 'pro', username: 'gamer' })
+      await expect(
+        syncHubSpotContact('tok', {
+          email: 'a@b.com',
+          subscription: 'pro',
+          username: 'gamer',
+        }),
+      ).resolves.toBeTruthy()
 
       const propertyCalls = fetchMock.mock.calls.filter((c) => isUrl(c, '/properties/contacts'))
       expect(propertyCalls).toHaveLength(2)
@@ -149,7 +164,7 @@ describe('lib/hubspot', () => {
 
       await expect(
         syncHubSpotContact('tok', { email: 'a@b.com', subscription: 'pro', username: 'g' }),
-      ).resolves.toBeUndefined()
+      ).resolves.toBeFalsy()
       expect(patchCalls).toBe(2)
       expect(captureException).toHaveBeenCalledOnce()
     })
@@ -162,7 +177,7 @@ describe('lib/hubspot', () => {
 
       await expect(
         syncHubSpotContact('tok', { email: 'a@b.com', subscription: 'pro', username: 'g' }),
-      ).resolves.toBeUndefined()
+      ).resolves.toBeFalsy()
       expect(captureException).toHaveBeenCalledOnce()
     })
 
@@ -174,7 +189,7 @@ describe('lib/hubspot', () => {
 
       await expect(
         syncHubSpotContact('tok', { email: 'a@b.com', subscription: 'pro', username: 'g' }),
-      ).resolves.toBeUndefined()
+      ).resolves.toBeFalsy()
       expect(captureException).toHaveBeenCalledOnce()
       expect(fetchMock.mock.calls.some((c) => isUrl(c, '/contacts/batch/upsert'))).toBeFalsy()
     })

--- a/src/__tests__/pages/api/hubspot/visitor-token.test.ts
+++ b/src/__tests__/pages/api/hubspot/visitor-token.test.ts
@@ -11,7 +11,7 @@ vi.mock('@/lib/api/get-server-session', () => ({ getServerSession: vi.fn() }))
 vi.mock('@/lib/auth', () => ({ authOptions: {} }))
 vi.mock('@/lib/hubspot', () => ({
   subscriptionToValue: vi.fn(() => 'pro'),
-  syncHubSpotContact: vi.fn().mockResolvedValue(undefined),
+  syncHubSpotContact: vi.fn().mockResolvedValue(true),
 }))
 vi.mock('@/utils/subscription', () => ({ getSubscription: vi.fn() }))
 vi.mock('node-fetch', () => ({ default: vi.fn() }))
@@ -38,7 +38,7 @@ describe('GET /api/hubspot/visitor-token', () => {
     vi.stubEnv('HUBSPOT_PRIVATE_APP_TOKEN', 'test-token')
     vi.mocked(getSubscription).mockResolvedValue(anyVal({ status: 'ACTIVE', tier: 'PRO' }))
     vi.mocked(fetch).mockResolvedValue(tokenOk())
-    vi.mocked(syncHubSpotContact).mockResolvedValue(undefined)
+    vi.mocked(syncHubSpotContact).mockResolvedValue(true)
     vi.mocked(subscriptionToValue).mockReturnValue('pro')
   })
 

--- a/src/__tests__/pages/api/hubspot/visitor-token.test.ts
+++ b/src/__tests__/pages/api/hubspot/visitor-token.test.ts
@@ -9,9 +9,9 @@ import { getSubscription } from '@/utils/subscription'
 
 vi.mock('@/lib/api/get-server-session', () => ({ getServerSession: vi.fn() }))
 vi.mock('@/lib/auth', () => ({ authOptions: {} }))
-vi.mock(import('@/lib/hubspot'), () => ({
-  subscriptionToValue: vi.fn<typeof subscriptionToValue>(() => 'pro'),
-  syncHubSpotContact: vi.fn<typeof syncHubSpotContact>().mockResolvedValue(true),
+vi.mock('@/lib/hubspot', () => ({
+  subscriptionToValue: vi.fn(() => 'pro'),
+  syncHubSpotContact: vi.fn().mockResolvedValue(undefined),
 }))
 vi.mock('@/utils/subscription', () => ({ getSubscription: vi.fn() }))
 vi.mock('node-fetch', () => ({ default: vi.fn() }))

--- a/src/__tests__/pages/api/hubspot/visitor-token.test.ts
+++ b/src/__tests__/pages/api/hubspot/visitor-token.test.ts
@@ -9,9 +9,9 @@ import { getSubscription } from '@/utils/subscription'
 
 vi.mock('@/lib/api/get-server-session', () => ({ getServerSession: vi.fn() }))
 vi.mock('@/lib/auth', () => ({ authOptions: {} }))
-vi.mock('@/lib/hubspot', () => ({
-  subscriptionToValue: vi.fn(() => 'pro'),
-  syncHubSpotContact: vi.fn().mockResolvedValue(true),
+vi.mock(import('@/lib/hubspot'), () => ({
+  subscriptionToValue: vi.fn<typeof subscriptionToValue>(() => 'pro'),
+  syncHubSpotContact: vi.fn<typeof syncHubSpotContact>().mockResolvedValue(true),
 }))
 vi.mock('@/utils/subscription', () => ({ getSubscription: vi.fn() }))
 vi.mock('node-fetch', () => ({ default: vi.fn() }))

--- a/src/__tests__/pages/api/stripe/create-checkout.test.ts
+++ b/src/__tests__/pages/api/stripe/create-checkout.test.ts
@@ -10,6 +10,7 @@ vi.stubEnv('NEXTAUTH_URL', 'https://dotabod.com')
 const mocks = vi.hoisted(() => ({
   createNowPaymentsInvoice: vi.fn(),
   featureFlags: { enableCryptoPayments: true },
+  getCheckoutPricePeriod: vi.fn(),
   getServerSession: vi.fn(),
   getSubscription: vi.fn(),
   prisma: {
@@ -36,6 +37,7 @@ const mocks = vi.hoisted(() => ({
       voidInvoice: vi.fn(),
     },
     prices: { retrieve: vi.fn() },
+    subscriptions: { list: vi.fn() },
   },
 }))
 
@@ -49,6 +51,7 @@ vi.mock('@/lib/nowpayments', () => ({
 }))
 vi.mock('@/utils/subscription', () => ({
   GRACE_PERIOD_END: new Date('2099-01-01'),
+  getCheckoutPricePeriod: mocks.getCheckoutPricePeriod,
   getCurrentPeriod: () => 'monthly',
   getSubscription: mocks.getSubscription,
   isInGracePeriod: () => false,
@@ -85,7 +88,8 @@ const buildReq = function buildReq(body: Record<string, unknown> = { priceId: 'p
 const arrangeTransaction = function arrangeTransaction(timeline: string[]) {
   const tx = {
     subscription: {
-      findFirst: vi.fn().mockResolvedValue({ stripeCustomerId: 'cus_1' }),
+      findFirst: vi.fn().mockResolvedValue(null),
+      findMany: vi.fn().mockResolvedValue([]),
       updateMany: vi.fn().mockResolvedValue({ count: 0 }),
     },
   }
@@ -102,14 +106,22 @@ describe('POST /api/stripe/create-checkout', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mocks.featureFlags.enableCryptoPayments = true
+    mocks.getCheckoutPricePeriod.mockReturnValue('monthly')
     mocks.getServerSession.mockResolvedValue(session)
     mocks.getSubscription.mockResolvedValue(null)
+    mocks.stripe.customers.list.mockResolvedValue({ data: [{ id: 'cus_1' }] })
     mocks.stripe.customers.retrieve.mockResolvedValue({ id: 'cus_1' })
     mocks.stripe.prices.retrieve.mockResolvedValue({
+      active: true,
       currency: 'usd',
+      id: 'price_mo',
       product: 'prod_1',
+      recurring: { interval: 'month', interval_count: 1 },
       type: 'recurring',
       unit_amount: 1300,
+    })
+    mocks.stripe.subscriptions.list.mockReturnValue({
+      autoPagingEach: async () => {},
     })
   })
 
@@ -249,6 +261,74 @@ describe('POST /api/stripe/create-checkout', () => {
       )
       expect(mocks.createNowPaymentsInvoice).not.toHaveBeenCalled()
       expect(mocks.prisma.nowPaymentsInvoice.create).not.toHaveBeenCalled()
+      expect(mocks.stripe.checkout.sessions.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          subscription_data: expect.objectContaining({ trial_period_days: 14 }),
+        }),
+      )
+    })
+
+    it('does not grant a trial when Stripe has a prior subscription missing from the database', async () => {
+      arrangeTransaction([])
+      mocks.stripe.subscriptions.list.mockImplementation(() => ({
+        autoPagingEach: async (callback: (subscription: unknown) => boolean | void) => {
+          callback({ id: 'sub_previous' })
+        },
+      }))
+      mocks.stripe.checkout.sessions.create.mockResolvedValue({
+        url: 'https://checkout.stripe.com/returning',
+      })
+
+      const { req, res } = buildReq({ priceId: 'price_mo' })
+      await handler(req, res)
+
+      expect(res._getStatusCode()).toBe(200)
+      expect(mocks.stripe.subscriptions.list).toHaveBeenCalledOnce()
+      expect(mocks.stripe.checkout.sessions.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          subscription_data: expect.not.objectContaining({ trial_period_days: expect.anything() }),
+        }),
+      )
+    })
+
+    it('does not grant a trial to an account with local subscription history', async () => {
+      const tx = arrangeTransaction([])
+      tx.subscription.findFirst.mockResolvedValue({ stripeCustomerId: 'cus_1' })
+      tx.subscription.findMany.mockResolvedValue([{ id: 'sub_previous' }])
+      mocks.stripe.checkout.sessions.create.mockResolvedValue({
+        url: 'https://checkout.stripe.com/returning',
+      })
+
+      const { req, res } = buildReq({ priceId: 'price_mo' })
+      await handler(req, res)
+
+      expect(res._getStatusCode()).toBe(200)
+      expect(mocks.stripe.subscriptions.list).not.toHaveBeenCalled()
+      expect(mocks.stripe.checkout.sessions.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          subscription_data: expect.not.objectContaining({ trial_period_days: expect.anything() }),
+        }),
+      )
+    })
+
+    it('fails closed on trial eligibility lookup errors without blocking checkout', async () => {
+      arrangeTransaction([])
+      mocks.stripe.subscriptions.list.mockImplementation(() => {
+        throw new Error('Stripe unavailable')
+      })
+      mocks.stripe.checkout.sessions.create.mockResolvedValue({
+        url: 'https://checkout.stripe.com/no-trial',
+      })
+
+      const { req, res } = buildReq({ priceId: 'price_mo' })
+      await handler(req, res)
+
+      expect(res._getStatusCode()).toBe(200)
+      expect(mocks.stripe.checkout.sessions.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          subscription_data: expect.not.objectContaining({ trial_period_days: expect.anything() }),
+        }),
+      )
     })
 
     it('falls back to a card checkout when the crypto feature flag is off', async () => {
@@ -291,6 +371,32 @@ describe('POST /api/stripe/create-checkout', () => {
     it('rejects requests missing priceId', async () => {
       const { req, res } = buildReq({})
       await handler(req, res)
+      expect(res._getStatusCode()).toBe(400)
+      expect(mocks.prisma.$transaction).not.toHaveBeenCalled()
+    })
+
+    it('rejects price IDs outside the configured checkout allowlist', async () => {
+      mocks.getCheckoutPricePeriod.mockReturnValue(null)
+      const { req, res } = buildReq({ priceId: 'price_unknown' })
+
+      await handler(req, res)
+
+      expect(res._getStatusCode()).toBe(400)
+      expect(mocks.stripe.prices.retrieve).not.toHaveBeenCalled()
+      expect(mocks.prisma.$transaction).not.toHaveBeenCalled()
+    })
+
+    it('rejects configured prices whose Stripe attributes do not match', async () => {
+      mocks.stripe.prices.retrieve.mockResolvedValue({
+        active: false,
+        currency: 'usd',
+        recurring: { interval: 'month', interval_count: 1 },
+        type: 'recurring',
+      })
+      const { req, res } = buildReq({ priceId: 'price_mo' })
+
+      await handler(req, res)
+
       expect(res._getStatusCode()).toBe(400)
       expect(mocks.prisma.$transaction).not.toHaveBeenCalled()
     })

--- a/src/__tests__/pages/api/stripe/create-checkout.test.ts
+++ b/src/__tests__/pages/api/stripe/create-checkout.test.ts
@@ -10,9 +10,9 @@ vi.stubEnv('NEXTAUTH_URL', 'https://dotabod.com')
 const mocks = vi.hoisted(() => ({
   createNowPaymentsInvoice: vi.fn(),
   featureFlags: { enableCryptoPayments: true },
-  getCheckoutPricePeriod: vi.fn(),
   getServerSession: vi.fn(),
   getSubscription: vi.fn(),
+  getCheckoutPricePeriod: vi.fn<(priceId: string) => 'annual' | 'lifetime' | 'monthly' | null>(),
   prisma: {
     $transaction: vi.fn(),
     nowPaymentsInvoice: {
@@ -25,7 +25,25 @@ const mocks = vi.hoisted(() => ({
     },
   },
   stripe: {
-    checkout: { sessions: { create: vi.fn() } },
+    subscriptions: {
+      list: vi.fn<
+        (params: {
+          customer: string
+          limit: number
+          status: 'all'
+        }) => Promise<{ data: { id: string }[] }>
+      >(),
+    },
+    checkout: {
+      sessions: {
+        create:
+          vi.fn<
+            (params: {
+              subscription_data?: { trial_period_days?: number }
+            }) => Promise<{ url: string }>
+          >(),
+      },
+    },
     customers: { create: vi.fn(), list: vi.fn(), retrieve: vi.fn() },
     invoiceItems: { create: vi.fn() },
     invoices: {
@@ -37,7 +55,6 @@ const mocks = vi.hoisted(() => ({
       voidInvoice: vi.fn(),
     },
     prices: { retrieve: vi.fn() },
-    subscriptions: { list: vi.fn() },
   },
 }))
 
@@ -49,7 +66,7 @@ vi.mock('@/lib/feature-flags', () => ({ featureFlags: mocks.featureFlags }))
 vi.mock('@/lib/nowpayments', () => ({
   createNowPaymentsInvoice: mocks.createNowPaymentsInvoice,
 }))
-vi.mock('@/utils/subscription', () => ({
+vi.mock(import('@/utils/subscription'), () => ({
   GRACE_PERIOD_END: new Date('2099-01-01'),
   getCheckoutPricePeriod: mocks.getCheckoutPricePeriod,
   getCurrentPeriod: () => 'monthly',
@@ -89,7 +106,6 @@ const arrangeTransaction = function arrangeTransaction(timeline: string[]) {
   const tx = {
     subscription: {
       findFirst: vi.fn().mockResolvedValue(null),
-      findMany: vi.fn().mockResolvedValue([]),
       updateMany: vi.fn().mockResolvedValue({ count: 0 }),
     },
   }
@@ -120,9 +136,7 @@ describe('POST /api/stripe/create-checkout', () => {
       type: 'recurring',
       unit_amount: 1300,
     })
-    mocks.stripe.subscriptions.list.mockReturnValue({
-      autoPagingEach: async () => {},
-    })
+    mocks.stripe.subscriptions.list.mockResolvedValue({ data: [] })
   })
 
   describe('connection pool deadlock regression', () => {
@@ -261,20 +275,13 @@ describe('POST /api/stripe/create-checkout', () => {
       )
       expect(mocks.createNowPaymentsInvoice).not.toHaveBeenCalled()
       expect(mocks.prisma.nowPaymentsInvoice.create).not.toHaveBeenCalled()
-      expect(mocks.stripe.checkout.sessions.create).toHaveBeenCalledWith(
-        expect.objectContaining({
-          subscription_data: expect.objectContaining({ trial_period_days: 14 }),
-        }),
-      )
+      const checkoutParams = mocks.stripe.checkout.sessions.create.mock.calls[0]?.[0]
+      expect(checkoutParams?.subscription_data?.trial_period_days).toBe(14)
     })
 
     it('does not grant a trial when Stripe has a prior subscription missing from the database', async () => {
       arrangeTransaction([])
-      mocks.stripe.subscriptions.list.mockImplementation(() => ({
-        autoPagingEach: async (callback: (subscription: unknown) => boolean | void) => {
-          callback({ id: 'sub_previous' })
-        },
-      }))
+      mocks.stripe.subscriptions.list.mockResolvedValue({ data: [{ id: 'sub_previous' }] })
       mocks.stripe.checkout.sessions.create.mockResolvedValue({
         url: 'https://checkout.stripe.com/returning',
       })
@@ -284,17 +291,13 @@ describe('POST /api/stripe/create-checkout', () => {
 
       expect(res._getStatusCode()).toBe(200)
       expect(mocks.stripe.subscriptions.list).toHaveBeenCalledOnce()
-      expect(mocks.stripe.checkout.sessions.create).toHaveBeenCalledWith(
-        expect.objectContaining({
-          subscription_data: expect.not.objectContaining({ trial_period_days: expect.anything() }),
-        }),
-      )
+      const checkoutParams = mocks.stripe.checkout.sessions.create.mock.calls[0]?.[0]
+      expect(checkoutParams?.subscription_data).not.toHaveProperty('trial_period_days')
     })
 
     it('does not grant a trial to an account with local subscription history', async () => {
       const tx = arrangeTransaction([])
       tx.subscription.findFirst.mockResolvedValue({ stripeCustomerId: 'cus_1' })
-      tx.subscription.findMany.mockResolvedValue([{ id: 'sub_previous' }])
       mocks.stripe.checkout.sessions.create.mockResolvedValue({
         url: 'https://checkout.stripe.com/returning',
       })
@@ -304,11 +307,8 @@ describe('POST /api/stripe/create-checkout', () => {
 
       expect(res._getStatusCode()).toBe(200)
       expect(mocks.stripe.subscriptions.list).not.toHaveBeenCalled()
-      expect(mocks.stripe.checkout.sessions.create).toHaveBeenCalledWith(
-        expect.objectContaining({
-          subscription_data: expect.not.objectContaining({ trial_period_days: expect.anything() }),
-        }),
-      )
+      const checkoutParams = mocks.stripe.checkout.sessions.create.mock.calls[0]?.[0]
+      expect(checkoutParams?.subscription_data).not.toHaveProperty('trial_period_days')
     })
 
     it('fails closed on trial eligibility lookup errors without blocking checkout', async () => {
@@ -324,11 +324,8 @@ describe('POST /api/stripe/create-checkout', () => {
       await handler(req, res)
 
       expect(res._getStatusCode()).toBe(200)
-      expect(mocks.stripe.checkout.sessions.create).toHaveBeenCalledWith(
-        expect.objectContaining({
-          subscription_data: expect.not.objectContaining({ trial_period_days: expect.anything() }),
-        }),
-      )
+      const checkoutParams = mocks.stripe.checkout.sessions.create.mock.calls[0]?.[0]
+      expect(checkoutParams?.subscription_data).not.toHaveProperty('trial_period_days')
     })
 
     it('falls back to a card checkout when the crypto feature flag is off', async () => {

--- a/src/__tests__/pages/api/stripe/create-checkout.test.ts
+++ b/src/__tests__/pages/api/stripe/create-checkout.test.ts
@@ -15,6 +15,24 @@ interface StripeCustomerCreateInput {
   email?: string
   metadata: Record<string, string>
 }
+interface StripeInvoiceItemCreateInput {
+  customer: string
+  invoice: string
+  price_data: {
+    currency: string
+    product: string
+    unit_amount: number
+  }
+}
+interface StripePriceResult {
+  active?: boolean
+  currency?: string
+  id?: string
+  product?: string
+  recurring?: { interval: string; interval_count: number }
+  type?: string
+  unit_amount?: number | null
+}
 
 const mocks = vi.hoisted(() => ({
   createNowPaymentsInvoice: vi.fn(),
@@ -50,7 +68,9 @@ const mocks = vi.hoisted(() => ({
       >(),
       retrieve: vi.fn<(customerId: string) => Promise<{ id: string }>>(),
     },
-    invoiceItems: { create: vi.fn() },
+    invoiceItems: {
+      create: vi.fn<(params: StripeInvoiceItemCreateInput) => Promise<Record<string, never>>>(),
+    },
     invoices: {
       create: vi.fn(),
       finalizeInvoice: vi.fn(),
@@ -59,7 +79,7 @@ const mocks = vi.hoisted(() => ({
       update: vi.fn(),
       voidInvoice: vi.fn(),
     },
-    prices: { retrieve: vi.fn() },
+    prices: { retrieve: vi.fn<(priceId: string) => Promise<StripePriceResult>>() },
     subscriptions: {
       list: vi.fn<
         (params: {

--- a/src/__tests__/pages/api/stripe/create-checkout.test.ts
+++ b/src/__tests__/pages/api/stripe/create-checkout.test.ts
@@ -6,13 +6,21 @@ import { z } from 'zod'
 vi.stubEnv('NOWPAYMENTS_API_KEY', 'test-api-key')
 vi.stubEnv('NOWPAYMENTS_IPN_SECRET', 'test-ipn-secret')
 vi.stubEnv('NEXTAUTH_URL', 'https://dotabod.com')
+vi.stubEnv('NEXT_PUBLIC_STRIPE_PRO_ANNUAL_PRICE_ID', 'price_yr')
+vi.stubEnv('NEXT_PUBLIC_STRIPE_PRO_LIFETIME_PRICE_ID', 'price_life')
+vi.stubEnv('NEXT_PUBLIC_STRIPE_PRO_MONTHLY_PRICE_ID', 'price_mo')
+
+type ExistingSubscription = { stripeCustomerId: string } | null
+interface StripeCustomerCreateInput {
+  email?: string
+  metadata: Record<string, string>
+}
 
 const mocks = vi.hoisted(() => ({
   createNowPaymentsInvoice: vi.fn(),
   featureFlags: { enableCryptoPayments: true },
   getServerSession: vi.fn(),
   getSubscription: vi.fn(),
-  getCheckoutPricePeriod: vi.fn<(priceId: string) => 'annual' | 'lifetime' | 'monthly' | null>(),
   prisma: {
     $transaction: vi.fn(),
     nowPaymentsInvoice: {
@@ -25,15 +33,6 @@ const mocks = vi.hoisted(() => ({
     },
   },
   stripe: {
-    subscriptions: {
-      list: vi.fn<
-        (params: {
-          customer: string
-          limit: number
-          status: 'all'
-        }) => Promise<{ data: { id: string }[] }>
-      >(),
-    },
     checkout: {
       sessions: {
         create:
@@ -44,7 +43,13 @@ const mocks = vi.hoisted(() => ({
           >(),
       },
     },
-    customers: { create: vi.fn(), list: vi.fn(), retrieve: vi.fn() },
+    customers: {
+      create: vi.fn<(params: StripeCustomerCreateInput) => Promise<{ id: string }>>(),
+      list: vi.fn<
+        (params: { email: string; limit: number }) => Promise<{ data: { id: string }[] }>
+      >(),
+      retrieve: vi.fn<(customerId: string) => Promise<{ id: string }>>(),
+    },
     invoiceItems: { create: vi.fn() },
     invoices: {
       create: vi.fn(),
@@ -55,6 +60,15 @@ const mocks = vi.hoisted(() => ({
       voidInvoice: vi.fn(),
     },
     prices: { retrieve: vi.fn() },
+    subscriptions: {
+      list: vi.fn<
+        (params: {
+          customer: string
+          limit: number
+          status: 'all'
+        }) => Promise<{ data: { id: string }[] }>
+      >(),
+    },
   },
 }))
 
@@ -66,9 +80,8 @@ vi.mock('@/lib/feature-flags', () => ({ featureFlags: mocks.featureFlags }))
 vi.mock('@/lib/nowpayments', () => ({
   createNowPaymentsInvoice: mocks.createNowPaymentsInvoice,
 }))
-vi.mock(import('@/utils/subscription'), () => ({
+vi.mock('@/utils/subscription', () => ({
   GRACE_PERIOD_END: new Date('2099-01-01'),
-  getCheckoutPricePeriod: mocks.getCheckoutPricePeriod,
   getCurrentPeriod: () => 'monthly',
   getSubscription: mocks.getSubscription,
   isInGracePeriod: () => false,
@@ -105,8 +118,8 @@ const buildReq = function buildReq(body: Record<string, unknown> = { priceId: 'p
 const arrangeTransaction = function arrangeTransaction(timeline: string[]) {
   const tx = {
     subscription: {
-      findFirst: vi.fn().mockResolvedValue(null),
-      updateMany: vi.fn().mockResolvedValue({ count: 0 }),
+      findFirst: vi.fn<() => Promise<ExistingSubscription>>().mockResolvedValue(null),
+      updateMany: vi.fn<() => Promise<{ count: number }>>().mockResolvedValue({ count: 0 }),
     },
   }
   mocks.prisma.$transaction.mockImplementation(async (callback: (tx: unknown) => unknown) => {
@@ -122,7 +135,6 @@ describe('POST /api/stripe/create-checkout', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mocks.featureFlags.enableCryptoPayments = true
-    mocks.getCheckoutPricePeriod.mockReturnValue('monthly')
     mocks.getServerSession.mockResolvedValue(session)
     mocks.getSubscription.mockResolvedValue(null)
     mocks.stripe.customers.list.mockResolvedValue({ data: [{ id: 'cus_1' }] })
@@ -373,7 +385,6 @@ describe('POST /api/stripe/create-checkout', () => {
     })
 
     it('rejects price IDs outside the configured checkout allowlist', async () => {
-      mocks.getCheckoutPricePeriod.mockReturnValue(null)
       const { req, res } = buildReq({ priceId: 'price_unknown' })
 
       await handler(req, res)

--- a/src/__tests__/utils/subscription.test.ts
+++ b/src/__tests__/utils/subscription.test.ts
@@ -169,6 +169,10 @@ describe('Subscription priority logic', () => {
 })
 
 describe(getSubscriptionTier, () => {
+  it('keeps explicit internal Pro records without a price ID', () => {
+    expect(getSubscriptionTier(null, SubscriptionStatus.ACTIVE)).toBe(SubscriptionTier.PRO)
+  })
+
   it('does not grant Pro for an unknown active price', () => {
     expect(getSubscriptionTier('price_unknown', SubscriptionStatus.ACTIVE)).toBe(
       SubscriptionTier.FREE,

--- a/src/__tests__/utils/subscription.test.ts
+++ b/src/__tests__/utils/subscription.test.ts
@@ -3,7 +3,7 @@ import type { Subscription } from '@prisma/client'
 import { describe, expect, it, vi } from 'vitest'
 
 import prisma from '@/lib/db'
-import { getBillingSummaryInfo, getSubscription } from '@/utils/subscription'
+import { getBillingSummaryInfo, getSubscription, getSubscriptionTier } from '@/utils/subscription'
 
 // We need to mock the module before importing it
 vi.mock('@/utils/subscription', async () => {
@@ -165,6 +165,14 @@ describe('Subscription priority logic', () => {
     // The actual behavior is that result is null when there are no subscriptions
     // And we're not in the grace period
     expect(result).toBeNull()
+  })
+})
+
+describe(getSubscriptionTier, () => {
+  it('does not grant Pro for an unknown active price', () => {
+    expect(getSubscriptionTier('price_unknown', SubscriptionStatus.ACTIVE)).toBe(
+      SubscriptionTier.FREE,
+    )
   })
 })
 

--- a/src/lib/hubspot.ts
+++ b/src/lib/hubspot.ts
@@ -42,16 +42,16 @@ export const subscriptionToValue = function subscriptionToValue(
   if (!sub?.tier || sub.tier === 'FREE') {
     return 'free'
   }
-  if (sub.transactionType === 'LIFETIME') {
-    return 'pro_lifetime'
-  }
   if (sub.status === 'TRIALING') {
     return 'pro_trial'
   }
   if (sub.status === 'PAST_DUE') {
     return 'pro_past_due'
   }
-  return 'pro'
+  if (sub.status !== 'ACTIVE') {
+    return 'free'
+  }
+  return sub.transactionType === 'LIFETIME' ? 'pro_lifetime' : 'pro'
 }
 
 // Memoized per server instance so we only attempt property creation once.
@@ -100,7 +100,7 @@ const ensureContactProperties = async function ensureContactProperties(token: st
 export const syncHubSpotContact = async function syncHubSpotContact(
   token: string,
   { email, username, subscription }: { email: string; username: string; subscription?: string },
-) {
+): Promise<boolean> {
   try {
     await ensureContactProperties(token)
     const properties = {
@@ -118,7 +118,7 @@ export const syncHubSpotContact = async function syncHubSpotContact(
       })
     const patchRes = await patch()
     if (patchRes.ok) {
-      return
+      return true
     }
     // Contact doesn't exist yet (visitor-identification didn't create one) — create it.
     if (patchRes.status === 404) {
@@ -128,7 +128,7 @@ export const syncHubSpotContact = async function syncHubSpotContact(
         method: 'POST',
       })
       if (createRes.ok) {
-        return
+        return true
       }
       // 409 means the contact was created between our PATCH (404) and POST — either
       // visitor-identification finished provisioning it, or a concurrent request won
@@ -136,7 +136,7 @@ export const syncHubSpotContact = async function syncHubSpotContact(
       if (createRes.status === 409) {
         const retryRes = await patch()
         if (retryRes.ok) {
-          return
+          return true
         }
         const retryDetail = await readBody(retryRes)
         throw new Error(
@@ -154,5 +154,6 @@ export const syncHubSpotContact = async function syncHubSpotContact(
     )
   } catch (error) {
     captureException(error instanceof Error ? error : new Error(String(error)))
+    return false
   }
 }

--- a/src/lib/stripe/checkout-prices.ts
+++ b/src/lib/stripe/checkout-prices.ts
@@ -1,0 +1,13 @@
+export type CheckoutPricePeriod = 'annual' | 'lifetime' | 'monthly'
+
+const CHECKOUT_PRICES: { id: string; period: CheckoutPricePeriod }[] = [
+  { id: process.env.NEXT_PUBLIC_STRIPE_PRO_MONTHLY_PRICE_ID ?? '', period: 'monthly' },
+  { id: process.env.NEXT_PUBLIC_STRIPE_PRO_ANNUAL_PRICE_ID ?? '', period: 'annual' },
+  { id: process.env.NEXT_PUBLIC_STRIPE_PRO_LIFETIME_PRICE_ID ?? '', period: 'lifetime' },
+]
+
+export const getCheckoutPricePeriod = function getCheckoutPricePeriod(
+  priceId: string,
+): CheckoutPricePeriod | null {
+  return CHECKOUT_PRICES.find((price) => price.id === priceId)?.period ?? null
+}

--- a/src/lib/stripe/services/gift-service.ts
+++ b/src/lib/stripe/services/gift-service.ts
@@ -1,8 +1,9 @@
-import { SubscriptionStatus, SubscriptionTier, TransactionType } from '@prisma/client'
+import { SubscriptionStatus, TransactionType } from '@prisma/client'
 import type { Prisma } from '@prisma/client'
 import type Stripe from 'stripe'
 
 import { stripe } from '@/lib/stripe-server'
+import { getSubscriptionTier } from '@/utils/subscription'
 
 import { withErrorHandling } from '../utils/error-handling'
 import { CustomerService } from './customer-service'
@@ -131,7 +132,7 @@ export class GiftService {
                       },
                       status: SubscriptionStatus.ACTIVE,
                       stripeCustomerId: recipientCustomerId,
-                      tier: SubscriptionTier.PRO,
+                      tier: getSubscriptionTier(null, SubscriptionStatus.ACTIVE),
                       transactionType:
                         giftType === 'lifetime'
                           ? TransactionType.LIFETIME

--- a/src/lib/stripe/services/gift-service.ts
+++ b/src/lib/stripe/services/gift-service.ts
@@ -1,9 +1,8 @@
-import { SubscriptionStatus, TransactionType } from '@prisma/client'
+import { SubscriptionStatus, SubscriptionTier, TransactionType } from '@prisma/client'
 import type { Prisma } from '@prisma/client'
 import type Stripe from 'stripe'
 
 import { stripe } from '@/lib/stripe-server'
-import { getSubscriptionTier } from '@/utils/subscription'
 
 import { withErrorHandling } from '../utils/error-handling'
 import { CustomerService } from './customer-service'
@@ -132,7 +131,7 @@ export class GiftService {
                       },
                       status: SubscriptionStatus.ACTIVE,
                       stripeCustomerId: recipientCustomerId,
-                      tier: getSubscriptionTier(null, SubscriptionStatus.ACTIVE),
+                      tier: SubscriptionTier.PRO,
                       transactionType:
                         giftType === 'lifetime'
                           ? TransactionType.LIFETIME

--- a/src/pages/api/stripe/create-checkout.ts
+++ b/src/pages/api/stripe/create-checkout.ts
@@ -43,20 +43,13 @@ const hasPriorStripeSubscription = async function hasPriorStripeSubscription(
   stripeCustomerIds: string[],
 ): Promise<boolean> {
   try {
-    const results = await Promise.all(
+    const subscriptionLists = await Promise.all(
       stripeCustomerIds.map(async (customer) => {
-        let hasSubscription = false
-        await stripe.subscriptions
-          .list({ customer, limit: 100, status: 'all' })
-          .autoPagingEach(() => {
-            hasSubscription = true
-            return false
-          })
-        return hasSubscription
+        return await stripe.subscriptions.list({ customer, limit: 1, status: 'all' })
       }),
     )
 
-    return results.some(Boolean)
+    return subscriptionLists.some((subscriptions) => subscriptions.data.length > 0)
   } catch (error) {
     console.error('Unable to verify prior Stripe subscriptions for trial eligibility:', error)
     return true
@@ -112,17 +105,11 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     // And any nested non-tx prisma write deadlocks the pool.
     const { customerId, hasSubscriptionHistory, subscriptionData } = await prisma.$transaction(
       async (tx) => {
-        const ensuredCustomerId = await ensureCustomer(session.user, tx)
-        const [currentSubscription, subscriptions] = await Promise.all([
-          getSubscription(session.user.id, tx),
-          tx.subscription.findMany({
-            select: { id: true },
-            where: { userId: session.user.id },
-          }),
-        ])
+        const customer = await ensureCustomer(session.user, tx)
+        const currentSubscription = await getSubscription(session.user.id, tx)
         return {
-          customerId: ensuredCustomerId,
-          hasSubscriptionHistory: subscriptions.length > 0,
+          customerId: customer.id,
+          hasSubscriptionHistory: customer.hasSubscriptionHistory,
           subscriptionData: currentSubscription,
         }
       },
@@ -173,7 +160,7 @@ const ensureCustomer = async function ensureCustomer(
     twitchId?: string | null
   },
   tx: Prisma.TransactionClient,
-): Promise<string> {
+): Promise<{ hasSubscriptionHistory: boolean; id: string }> {
   // Look for any existing subscription to get a customer ID
   const subscription = await tx.subscription.findFirst({
     // Use the most recent subscription
@@ -225,7 +212,7 @@ const ensureCustomer = async function ensureCustomer(
     throw new Error('Unable to establish customer ID')
   }
 
-  return customerId
+  return { hasSubscriptionHistory: subscription !== null, id: customerId }
 }
 
 const createStripeCustomer = async function createStripeCustomer(user: {
@@ -368,7 +355,7 @@ const createCheckoutSession = async function createCheckoutSession(
 }
 
 const createCryptoInvoice = async function createCryptoInvoice(
-  params: Omit<CheckoutSessionParams, 'isGift' | 'isCryptoPayment' | 'isPaypalPayment'>,
+  params: Omit<CheckoutSessionParams, 'isCryptoPayment' | 'isTrialEligible'>,
 ): Promise<string> {
   const {
     customerId,

--- a/src/pages/api/stripe/create-checkout.ts
+++ b/src/pages/api/stripe/create-checkout.ts
@@ -9,12 +9,8 @@ import prisma from '@/lib/db'
 import { featureFlags } from '@/lib/feature-flags'
 import { createAndStoreCryptoInvoice } from '@/lib/nowpayments-checkout'
 import { stripe } from '@/lib/stripe-server'
-import {
-  GRACE_PERIOD_END,
-  getCheckoutPricePeriod,
-  getSubscription,
-  isInGracePeriod,
-} from '@/utils/subscription'
+import { getCheckoutPricePeriod } from '@/lib/stripe/checkout-prices'
+import { GRACE_PERIOD_END, getSubscription, isInGracePeriod } from '@/utils/subscription'
 
 interface CheckoutRequestBody {
   priceId: string
@@ -44,9 +40,9 @@ const hasPriorStripeSubscription = async function hasPriorStripeSubscription(
 ): Promise<boolean> {
   try {
     const subscriptionLists = await Promise.all(
-      stripeCustomerIds.map(async (customer) => {
-        return await stripe.subscriptions.list({ customer, limit: 1, status: 'all' })
-      }),
+      stripeCustomerIds.map((customer) =>
+        stripe.subscriptions.list({ customer, limit: 1, status: 'all' }),
+      ),
     )
 
     return subscriptionLists.some((subscriptions) => subscriptions.data.length > 0)

--- a/src/pages/api/stripe/create-checkout.ts
+++ b/src/pages/api/stripe/create-checkout.ts
@@ -9,13 +9,58 @@ import prisma from '@/lib/db'
 import { featureFlags } from '@/lib/feature-flags'
 import { createAndStoreCryptoInvoice } from '@/lib/nowpayments-checkout'
 import { stripe } from '@/lib/stripe-server'
-import { GRACE_PERIOD_END, getSubscription, isInGracePeriod } from '@/utils/subscription'
+import {
+  GRACE_PERIOD_END,
+  getCheckoutPricePeriod,
+  getSubscription,
+  isInGracePeriod,
+} from '@/utils/subscription'
 
 interface CheckoutRequestBody {
   priceId: string
-  period?: string
-  isGift?: boolean
   paymentMethod?: string
+}
+
+const isConfiguredCheckoutPrice = function isConfiguredCheckoutPrice(
+  price: Stripe.Price,
+  pricePeriod: 'annual' | 'lifetime' | 'monthly',
+  expectedInterval: 'month' | 'year',
+): boolean {
+  if (!price.active || price.currency !== 'usd') {
+    return false
+  }
+  if (pricePeriod === 'lifetime') {
+    return price.type === 'one_time'
+  }
+  return (
+    price.type === 'recurring' &&
+    price.recurring?.interval === expectedInterval &&
+    price.recurring.interval_count === 1
+  )
+}
+
+const hasPriorStripeSubscription = async function hasPriorStripeSubscription(
+  stripeCustomerIds: string[],
+): Promise<boolean> {
+  try {
+    const results = await Promise.all(
+      stripeCustomerIds.map(async (customer) => {
+        let hasSubscription = false
+        await stripe.subscriptions
+          .list({ customer, limit: 100, status: 'all' })
+          .autoPagingEach(() => {
+            hasSubscription = true
+            return false
+          })
+        return hasSubscription
+      }),
+    )
+
+    return results.some(Boolean)
+  } catch (error) {
+    console.error('Unable to verify prior Stripe subscriptions for trial eligibility:', error)
+    return true
+  }
 }
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
@@ -37,14 +82,26 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     }
 
     // Parse and validate request body
-    const { priceId, isGift, paymentMethod } = (await req.body) as CheckoutRequestBody
+    const { priceId, paymentMethod } = (await req.body) as CheckoutRequestBody
     if (!priceId) {
       res.status(400).json({ error: 'Price ID is required' })
       return
     }
 
+    const pricePeriod = getCheckoutPricePeriod(priceId)
+    if (!pricePeriod) {
+      res.status(400).json({ error: 'Price is not available for checkout' })
+      return
+    }
+
     // Verify price and determine purchase type
     const price = await stripe.prices.retrieve(priceId)
+    const expectedInterval = pricePeriod === 'monthly' ? 'month' : 'year'
+    if (!isConfiguredCheckoutPrice(price, pricePeriod, expectedInterval)) {
+      res.status(400).json({ error: 'Price is not available for checkout' })
+      return
+    }
+
     const isRecurring = price.type === 'recurring'
     const isLifetime = !isRecurring
     // Check if user wants to pay with crypto and if feature is enabled
@@ -53,11 +110,21 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     // Keep this transaction narrow: production runs with connection_limit=1, so
     // Any external API call inside the callback holds the only pool connection
     // And any nested non-tx prisma write deadlocks the pool.
-    const { customerId, subscriptionData } = await prisma.$transaction(
+    const { customerId, hasSubscriptionHistory, subscriptionData } = await prisma.$transaction(
       async (tx) => {
-        const customerId = await ensureCustomer(session.user, tx)
-        const subscriptionData = await getSubscription(session.user.id, tx)
-        return { customerId, subscriptionData }
+        const ensuredCustomerId = await ensureCustomer(session.user, tx)
+        const [currentSubscription, subscriptions] = await Promise.all([
+          getSubscription(session.user.id, tx),
+          tx.subscription.findMany({
+            select: { id: true },
+            where: { userId: session.user.id },
+          }),
+        ])
+        return {
+          customerId: ensuredCustomerId,
+          hasSubscriptionHistory: subscriptions.length > 0,
+          subscriptionData: currentSubscription,
+        }
       },
       {
         isolationLevel: Prisma.TransactionIsolationLevel.ReadCommitted,
@@ -65,14 +132,19 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       },
     )
 
+    const isTrialEligible =
+      isRecurring && !isCryptoPayment && !hasSubscriptionHistory
+        ? !(await hasPriorStripeSubscription([customerId]))
+        : false
+
     const checkoutUrl = await createCheckoutSession({
       customerId,
       email: session.user.email ?? '',
       image: session.user.image ?? '',
       isCryptoPayment,
-      isGift,
       isLifetime,
       isRecurring,
+      isTrialEligible,
       locale: session.user.locale ?? '',
       name: session.user.name ?? '',
       priceId,
@@ -196,8 +268,8 @@ interface CheckoutSessionParams {
   locale: string
   twitchId: string
   referer?: string
-  isGift?: boolean
   isCryptoPayment: boolean
+  isTrialEligible: boolean
 }
 
 const createCheckoutSession = async function createCheckoutSession(
@@ -216,8 +288,8 @@ const createCheckoutSession = async function createCheckoutSession(
     locale,
     twitchId,
     referer,
-    isGift,
     isCryptoPayment,
+    isTrialEligible,
   } = params
 
   // If this is a crypto payment, use the NOWPayments hosted invoice flow
@@ -247,13 +319,10 @@ const createCheckoutSession = async function createCheckoutSession(
   // Simplified trial period logic
   let trialDays = 0
 
-  if (isGift) {
-    // No trial for gift purchases
-    trialDays = 0
-  } else if (isInGracePeriod()) {
+  if (isInGracePeriod()) {
     // If we're in the grace period, use days until grace period ends as trial
     trialDays = Math.ceil((GRACE_PERIOD_END.getTime() - now.getTime()) / (1000 * 60 * 60 * 24))
-  } else if (isRecurring) {
+  } else if (isRecurring && isTrialEligible) {
     // Standard trial for new self-subscriptions
     trialDays = 14
   }
@@ -274,7 +343,7 @@ const createCheckoutSession = async function createCheckoutSession(
       email,
       image,
       isCryptoPayment: 'false',
-      isGift: isGift ? 'true' : 'false',
+      isGift: 'false',
       isNewSubscription: isRecurring && !subscriptionData?.stripeSubscriptionId ? 'true' : 'false',
       isUpgradeToLifetime: isLifetime && subscriptionData?.stripeSubscriptionId ? 'true' : 'false',
       locale,

--- a/src/utils/subscription.ts
+++ b/src/utils/subscription.ts
@@ -324,29 +324,6 @@ const PRICE_IDS: SubscriptionPriceId[] = [
 // Alias of PRICE_IDS rather than a duplicated literal.
 export const CRYPTO_PRICE_IDS: SubscriptionPriceId[] = PRICE_IDS
 
-export const getCheckoutPricePeriod = function getCheckoutPricePeriod(
-  priceId: string,
-): PricePeriod | null {
-  const price = PRICE_IDS.find((candidate) =>
-    [candidate.monthly, candidate.annual, candidate.lifetime].includes(priceId),
-  )
-
-  if (!price) {
-    return null
-  }
-  if (price.monthly === priceId) {
-    return 'monthly'
-  }
-  if (price.annual === priceId) {
-    return 'annual'
-  }
-  if (price.lifetime === priceId) {
-    return 'lifetime'
-  }
-
-  return null
-}
-
 export const getPriceId = function getPriceId(
   tier: Exclude<SubscriptionTier, typeof SUBSCRIPTION_TIERS.FREE>,
   period: PricePeriod,

--- a/src/utils/subscription.ts
+++ b/src/utils/subscription.ts
@@ -970,11 +970,15 @@ export const getSubscriptionTier = function getSubscriptionTier(
   status: SubscriptionStatus | null,
 ): SubscriptionTier {
   if (isSubscriptionActive({ status })) {
+    if (priceId === null || priceId === undefined) {
+      return SUBSCRIPTION_TIERS.PRO
+    }
+
     // Check both regular and gift price IDs
     const allPriceIds = [...PRICE_IDS, ...GIFT_PRICE_IDS, ...CRYPTO_PRICE_IDS]
 
     const tierFromPrice = allPriceIds.find((price) =>
-      [price.monthly, price.annual, price.lifetime].includes(priceId ?? ''),
+      [price.monthly, price.annual, price.lifetime].includes(priceId),
     )?.tier
 
     return tierFromPrice ?? SUBSCRIPTION_TIERS.FREE

--- a/src/utils/subscription.ts
+++ b/src/utils/subscription.ts
@@ -324,6 +324,29 @@ const PRICE_IDS: SubscriptionPriceId[] = [
 // Alias of PRICE_IDS rather than a duplicated literal.
 export const CRYPTO_PRICE_IDS: SubscriptionPriceId[] = PRICE_IDS
 
+export const getCheckoutPricePeriod = function getCheckoutPricePeriod(
+  priceId: string,
+): PricePeriod | null {
+  const price = PRICE_IDS.find((candidate) =>
+    [candidate.monthly, candidate.annual, candidate.lifetime].includes(priceId),
+  )
+
+  if (!price) {
+    return null
+  }
+  if (price.monthly === priceId) {
+    return 'monthly'
+  }
+  if (price.annual === priceId) {
+    return 'annual'
+  }
+  if (price.lifetime === priceId) {
+    return 'lifetime'
+  }
+
+  return null
+}
+
 export const getPriceId = function getPriceId(
   tier: Exclude<SubscriptionTier, typeof SUBSCRIPTION_TIERS.FREE>,
   period: PricePeriod,
@@ -954,7 +977,7 @@ export const getSubscriptionTier = function getSubscriptionTier(
       [price.monthly, price.annual, price.lifetime].includes(priceId ?? ''),
     )?.tier
 
-    return tierFromPrice ?? SUBSCRIPTION_TIERS.PRO
+    return tierFromPrice ?? SUBSCRIPTION_TIERS.FREE
   }
 
   return SUBSCRIPTION_TIERS.FREE

--- a/supabase/functions/sync-hubspot/index.ts
+++ b/supabase/functions/sync-hubspot/index.ts
@@ -201,10 +201,11 @@ const fetchChanged = async function fetchChanged(
       select distinct on (s."userId") s."userId",
         case
           when s.tier::text = 'FREE' then 'free'
-          when s."transactionType"::text = 'LIFETIME' then 'pro_lifetime'
           when s.status::text = 'TRIALING' then 'pro_trial'
           when s.status::text = 'PAST_DUE' then 'pro_past_due'
-          else 'pro'
+          when s.status::text = 'ACTIVE' and s."transactionType"::text = 'LIFETIME' then 'pro_lifetime'
+          when s.status::text = 'ACTIVE' then 'pro'
+          else 'free'
         end as sub_value
       from subscriptions s
       order by s."userId",
@@ -240,10 +241,11 @@ const fetchByEmails = async function fetchByEmails(
       select distinct on (s."userId") s."userId",
         case
           when s.tier::text = 'FREE' then 'free'
-          when s."transactionType"::text = 'LIFETIME' then 'pro_lifetime'
           when s.status::text = 'TRIALING' then 'pro_trial'
           when s.status::text = 'PAST_DUE' then 'pro_past_due'
-          else 'pro'
+          when s.status::text = 'ACTIVE' and s."transactionType"::text = 'LIFETIME' then 'pro_lifetime'
+          when s.status::text = 'ACTIVE' then 'pro'
+          else 'free'
         end as sub_value
       from subscriptions s
       order by s."userId",

--- a/tools/quality/oxlint-baseline.json
+++ b/tools/quality/oxlint-baseline.json
@@ -229,6 +229,26 @@
         "severity": "error"
       }
     },
+    "006bfd49ddf82e63efcc8d523e3318778ba130b3ae2fb4199bd8c4f7cd179df0": {
+      "count": 1,
+      "summary": {
+        "code": "eslint(complexity)",
+        "file": "src/lib/hooks/use-socket.tsx",
+        "labels": [
+          {
+            "context": {
+              "current": "return () => {",
+              "next": "clearInterval(connectionMonitor)",
+              "previous": "// Clean up"
+            },
+            "span": "() => {\n      clearInterval(connectionMonitor)\n      clearInterval(diagnosticHeartbeat)\n      // Clear all message timeouts\n      messageTimeoutsRef.current.forEach((timeoutId) => {\n        clearTimeout(timeoutId)\n      })\n      messageTimeoutsRef.current.clear()\n\n      // Don't disconnect the socket on every effect cleanup\n      // Only clean up event handlers\n      socket?.off('connect')\n      socket?.off('connect_error')\n      socket?.off('disconnect')\n      socket?.off('DATA_buildings')\n      socket?.off('DATA_heroes')\n      socket?.off('DATA_couriers')\n      socket?.off('DATA_creeps')\n      socket?.off('DATA_hero_units')\n      socket?.off('STATUS')\n      socket?.off('requestHeroData')\n      socket?.off('requestMatchData')\n      socket?.off('block')\n      socket?.off('paused')\n      socket?.off('notable-players')\n      socket?.off('aegis-picked-up')\n      socket?.off('chatMessage')\n      socket?.off('roshan-killed')\n      socket?.off('auth_error')\n      socket?.off('refresh-settings')\n      activeSocket.off('diagnostic-overlay-probe')\n      socket?.off('channelPollOrBet')\n      socket?.off('update-medal')\n      socket?.off('update-wl')\n      socket?.off('update-radiant-win-chance')\n      socket?.off('refresh')\n    }",
+            "text": ""
+          }
+        ],
+        "message": "function has a complexity of 25. Maximum allowed is 20.",
+        "severity": "error"
+      }
+    },
     "0074ee27ee7a6b083f4f42d9e7a8fa008d0eea98744432a50c069f86ab9695ee": {
       "count": 1,
       "summary": {
@@ -2970,26 +2990,6 @@
         "severity": "error"
       }
     },
-    "059f1b0a005ec0c761a66ff778577b27a21b03bacc7fb0635e2ef95ba65fc3aa": {
-      "count": 1,
-      "summary": {
-        "code": "typescript(no-unsafe-argument)",
-        "file": "src/__tests__/pages/api/hubspot/visitor-token.test.ts",
-        "labels": [
-          {
-            "context": {
-              "current": "vi.mocked(fetch).mockResolvedValue(tokenOk())",
-              "next": "vi.mocked(syncHubSpotContact).mockResolvedValue(undefined)",
-              "previous": "vi.mocked(getSubscription).mockResolvedValue(anyVal({ status: 'ACTIVE', tier: 'PRO' }))"
-            },
-            "span": "tokenOk()",
-            "text": ""
-          }
-        ],
-        "message": "Unsafe argument of type any assigned to a parameter of type Response.",
-        "severity": "error"
-      }
-    },
     "05a24bc01d3f91b8c79dd9c97e1a4232ffcc29a248a13f9f745a97d44dcbf7be": {
       "count": 1,
       "summary": {
@@ -3136,35 +3136,6 @@
           }
         ],
         "message": "Unexpected nullable string value in conditional. Please handle the nullish and empty string cases explicitly.",
-        "severity": "error"
-      }
-    },
-    "05e658a4b24226ef818c4edc4692818a68dada283c41b0f8a562a91477b28fc4": {
-      "count": 1,
-      "summary": {
-        "code": "eslint(no-use-before-define)",
-        "file": "src/pages/api/stripe/create-checkout.ts",
-        "labels": [
-          {
-            "context": {
-              "current": "return await createCryptoInvoice({",
-              "next": "customerId,",
-              "previous": "if (isCryptoPayment) {"
-            },
-            "span": "createCryptoInvoice",
-            "text": "used here"
-          },
-          {
-            "context": {
-              "current": "const createCryptoInvoice = async function createCryptoInvoice(",
-              "next": "params: Omit<CheckoutSessionParams, 'isGift' | 'isCryptoPayment' | 'isPaypalPayment'>,",
-              "previous": ""
-            },
-            "span": "createCryptoInvoice",
-            "text": "defined here"
-          }
-        ],
-        "message": "'createCryptoInvoice' was used before it was defined.",
         "severity": "error"
       }
     },
@@ -7819,6 +7790,26 @@
         "severity": "error"
       }
     },
+    "0ddd402a7e7292078cdcbc25ebd7b435d9c032c464a717cb18063ed5b50d03a0": {
+      "count": 1,
+      "summary": {
+        "code": "typescript(strict-boolean-expressions)",
+        "file": "src/pages/api/stripe/create-checkout.ts",
+        "labels": [
+          {
+            "context": {
+              "current": "isNewSubscription: isRecurring && !subscriptionData?.stripeSubscriptionId ? 'true' : 'false',",
+              "next": "isUpgradeToLifetime: isLifetime && subscriptionData?.stripeSubscriptionId ? 'true' : 'false',",
+              "previous": "isGift: 'false',"
+            },
+            "span": "subscriptionData?.stripeSubscriptionId",
+            "text": ""
+          }
+        ],
+        "message": "Unexpected nullable string value in conditional. Please handle the nullish and empty string cases explicitly.",
+        "severity": "error"
+      }
+    },
     "0de06c92167d1c9430f8dcbbd52fb9000ca01a8bb1655550d963b110347e9496": {
       "count": 1,
       "summary": {
@@ -8485,26 +8476,6 @@
           }
         ],
         "message": "Avoid referencing unbound methods which may cause unintentional scoping of `this`.",
-        "severity": "error"
-      }
-    },
-    "0f0b08e7a7ee80eec9abe8eb1d666f7af5b8b732fea4429be6e26c90e520df4b": {
-      "count": 1,
-      "summary": {
-        "code": "eslint(complexity)",
-        "file": "src/lib/hooks/use-socket.tsx",
-        "labels": [
-          {
-            "context": {
-              "current": "return () => {",
-              "next": "clearInterval(connectionMonitor)",
-              "previous": "// Clean up"
-            },
-            "span": "() => {\n      clearInterval(connectionMonitor)\n      clearInterval(diagnosticHeartbeat)\n      // Clear all message timeouts\n      messageTimeoutsRef.current.forEach((timeoutId) => {\n        clearTimeout(timeoutId)\n      })\n      messageTimeoutsRef.current.clear()\n\n      // Don't disconnect the socket on every effect cleanup\n      // Only clean up event handlers\n      socket?.off('connect')\n      socket?.off('connect_error')\n      socket?.off('disconnect')\n      socket?.off('DATA_buildings')\n      socket?.off('DATA_heroes')\n      socket?.off('DATA_couriers')\n      socket?.off('DATA_creeps')\n      socket?.off('DATA_hero_units')\n      socket?.off('STATUS')\n      socket?.off('requestHeroData')\n      socket?.off('requestMatchData')\n      socket?.off('block')\n      socket?.off('paused')\n      socket?.off('notable-players')\n      socket?.off('aegis-picked-up')\n      socket?.off('chatMessage')\n      socket?.off('roshan-killed')\n      socket?.off('auth_error')\n      socket?.off('refresh-settings')\n      socket?.off('channelPollOrBet')\n      socket?.off('update-medal')\n      socket?.off('update-wl')\n      socket?.off('update-radiant-win-chance')\n      socket?.off('refresh')\n    }",
-            "text": ""
-          }
-        ],
-        "message": "function has a complexity of 25. Maximum allowed is 20.",
         "severity": "error"
       }
     },
@@ -11473,6 +11444,26 @@
         "severity": "error"
       }
     },
+    "148383e4f18416044690d2e4e7629b0d4d4caa1b4c5dcbca2c3bbb67757440f5": {
+      "count": 1,
+      "summary": {
+        "code": "eslint(complexity)",
+        "file": "src/pages/api/stripe/create-checkout.ts",
+        "labels": [
+          {
+            "context": {
+              "current": "const createCheckoutSession = async function createCheckoutSession(",
+              "next": "params: CheckoutSessionParams,",
+              "previous": ""
+            },
+            "span": "async function createCheckoutSession(\n  params: CheckoutSessionParams,\n): Promise<string> {\n  const {\n    customerId,\n    priceId,\n    isRecurring,\n    isLifetime,\n    subscriptionData,\n    userId,\n    email,\n    name,\n    image,\n    locale,\n    twitchId,\n    referer,\n    isCryptoPayment,\n    isTrialEligible,\n  } = params\n\n  // If this is a crypto payment, use the NOWPayments hosted invoice flow\n  if (isCryptoPayment) {\n    return await createCryptoInvoice({\n      customerId,\n      email,\n      image,\n      isLifetime,\n      isRecurring,\n      locale,\n      name,\n      priceId,\n      referer,\n      subscriptionData,\n      twitchId,\n      userId,\n    })\n  }\n\n  // Handle regular Stripe checkout\n  const baseUrl = process.env.NEXTAUTH_URL ?? ''\n\n  // Calculate trial period based on grace period\n  const now = new Date()\n\n  // Simplified trial period logic\n  let trialDays = 0\n\n  if (isInGracePeriod()) {\n    // If we're in the grace period, use days until grace period ends as trial\n    trialDays = Math.ceil((GRACE_PERIOD_END.getTime() - now.getTime()) / (1000 * 60 * 60 * 24))\n  } else if (isRecurring && isTrialEligible) {\n    // Standard trial for new self-subscriptions\n    trialDays = 14\n  }\n\n  // Build success URL with simplified parameters\n  const successUrl = `${baseUrl || 'https://dotabod.com'}/dashboard?paid=true&crypto=false&trial=${isRecurring && trialDays > 0}&trialDays=${trialDays}`\n\n  const cancelUrl = referer?.includes('/dashboard')\n    ? `${baseUrl || 'https://dotabod.com'}/dashboard/billing?paid=false`\n    : `${baseUrl || 'https://dotabod.com'}/?paid=false`\n\n  const session = await stripe.checkout.sessions.create({\n    allow_promotion_codes: true,\n    cancel_url: cancelUrl,\n    customer: customerId,\n    line_items: [{ price: priceId, quantity: 1 }],\n    metadata: {\n      email,\n      image,\n      isCryptoPayment: 'false',\n      isGift: 'false',\n      isNewSubscription: isRecurring && !subscriptionData?.stripeSubscriptionId ? 'true' : 'false',\n      isUpgradeToLifetime: isLifetime && subscriptionData?.stripeSubscriptionId ? 'true' : 'false',\n      locale,\n      name,\n      previousSubscriptionId: subscriptionData?.stripeSubscriptionId ?? '',\n      twitchId,\n      userId,\n    },\n    mode: isRecurring ? 'subscription' : 'payment',\n    subscription_data: isRecurring\n      ? {\n          ...(trialDays > 0 ? { trial_period_days: trialDays } : {}),\n          trial_settings: {\n            end_behavior: { missing_payment_method: 'cancel' },\n          },\n        }\n      : undefined,\n    success_url: successUrl,\n  })\n\n  return session.url ?? ''\n}",
+            "text": ""
+          }
+        ],
+        "message": "async function `createCheckoutSession` has a complexity of 24. Maximum allowed is 20.",
+        "severity": "error"
+      }
+    },
     "1495d4ecda8207e25c975446047d2bd163757fa5edc11980d511de52f572b0f4": {
       "count": 1,
       "summary": {
@@ -13467,26 +13458,6 @@
         "severity": "error"
       }
     },
-    "1865c1aeafe2951118fa056c0188e29bf85c3cd88243083cea26abedb9e3014d": {
-      "count": 1,
-      "summary": {
-        "code": "typescript(consistent-return)",
-        "file": "src/lib/hooks/use-socket.tsx",
-        "labels": [
-          {
-            "context": {
-              "current": "return () => {",
-              "next": "clearInterval(connectionMonitor)",
-              "previous": "// Clean up"
-            },
-            "span": "return () => {\n      clearInterval(connectionMonitor)\n      clearInterval(diagnosticHeartbeat)\n      // Clear all message timeouts\n      messageTimeoutsRef.current.forEach((timeoutId) => {\n        clearTimeout(timeoutId)\n      })\n      messageTimeoutsRef.current.clear()\n\n      // Don't disconnect the socket on every effect cleanup\n      // Only clean up event handlers\n      socket?.off('connect')\n      socket?.off('connect_error')\n      socket?.off('disconnect')\n      socket?.off('DATA_buildings')\n      socket?.off('DATA_heroes')\n      socket?.off('DATA_couriers')\n      socket?.off('DATA_creeps')\n      socket?.off('DATA_hero_units')\n      socket?.off('STATUS')\n      socket?.off('requestHeroData')\n      socket?.off('requestMatchData')\n      socket?.off('block')\n      socket?.off('paused')\n      socket?.off('notable-players')\n      socket?.off('aegis-picked-up')\n      socket?.off('chatMessage')\n      socket?.off('roshan-killed')\n      socket?.off('auth_error')\n      socket?.off('refresh-settings')\n      socket?.off('channelPollOrBet')\n      socket?.off('update-medal')\n      socket?.off('update-wl')\n      socket?.off('update-radiant-win-chance')\n      socket?.off('refresh')\n    }",
-            "text": ""
-          }
-        ],
-        "message": "Function expected no return value.",
-        "severity": "error"
-      }
-    },
     "186ee163dc6a7f96008485ed67d10c4a6f837fd12e45642196b7b99773788b80": {
       "count": 1,
       "summary": {
@@ -14565,26 +14536,6 @@
         "severity": "error"
       }
     },
-    "1ab26b15583597732e7a96bb21689a142d03898471232dc023e16d205e7cd8cd": {
-      "count": 3,
-      "summary": {
-        "code": "vitest(require-mock-type-parameters)",
-        "file": "src/__tests__/pages/api/stripe/create-checkout.test.ts",
-        "labels": [
-          {
-            "context": {
-              "current": "customers: { create: vi.fn(), list: vi.fn(), retrieve: vi.fn() },",
-              "next": "invoiceItems: { create: vi.fn() },",
-              "previous": "checkout: { sessions: { create: vi.fn() } },"
-            },
-            "span": "fn",
-            "text": ""
-          }
-        ],
-        "message": "Missing type parameters on mock function call",
-        "severity": "error"
-      }
-    },
     "1ab48a196028ba3dbf6ad49be74a5388b9d5ff651591aba2fc923fe08c6868ad": {
       "count": 1,
       "summary": {
@@ -15483,26 +15434,6 @@
         "severity": "error"
       }
     },
-    "1ca5b828ff7d234f207802c6332439e66e2f4734fd5aa814e04e933b93a09fea": {
-      "count": 1,
-      "summary": {
-        "code": "react-doctor(effect-needs-cleanup)",
-        "file": "src/lib/hooks/use-socket.tsx",
-        "labels": [
-          {
-            "context": {
-              "current": "useEffect(() => {",
-              "next": "if (!userId) {",
-              "previous": ""
-            },
-            "span": "useEffect(() => {\n    if (!userId) {\n      return\n    }\n\n    let lastReceivedTime = Date.now()\n\n    console.log('Connecting to socket init...', { userId })\n\n    // Create socket connection only once per userId\n    if (!socket) {\n      socket = io(process.env.NEXT_PUBLIC_GSI_WEBSOCKET_URL, {\n        auth: { token: userId },\n        reconnection: true,\n        reconnectionAttempts: Number.POSITIVE_INFINITY,\n        reconnectionDelay: 1000,\n        reconnectionDelayMax: 5000,\n        timeout: 20_000,\n      })\n\n      console.log('Socket instance created:', Boolean(socket))\n    }\n\n    // Use socket.io's built-in ping event to track connection health\n    socket.io.on('ping', () => {\n      lastReceivedTime = Date.now()\n    })\n\n    // Monitor for stale connections\n    const connectionMonitor = setInterval(() => {\n      if (Date.now() - lastReceivedTime > 45_000) {\n        // 45s = 3 missed pings\n        console.log('Connection appears stale, reconnecting...')\n        socket?.disconnect()\n        socket?.connect()\n      }\n    }, 15_000)\n\n    const diagnosticHeartbeat = setInterval(() => {\n      if (socket?.connected) {\n        socket.emit('diagnostic-heartbeat')\n      }\n    }, 60_000)\n\n    // Update lastReceivedTime whenever we get any data\n    const updateLastReceived = () => {\n      lastReceivedTime = Date.now()\n    }\n\n    // Add handlers for all existing events\n    socket.on('DATA_buildings', (data) => {\n      updateLastReceived()\n      dispatch(setMinimapDataBuildings(data))\n    })\n\n    socket.on('DATA_heroes', (data) => {\n      updateLastReceived()\n      dispatch(setMinimapDataHeroes(data))\n    })\n\n    socket.on('DATA_couriers', (data: CourierData[]) => {\n      updateLastReceived()\n      dispatch(setMinimapDataCouriers(data))\n    })\n\n    socket.on('DATA_creeps', (data: CreepData[]) => {\n      updateLastReceived()\n      dispatch(setMinimapDataCreeps(data))\n    })\n    socket.on('DATA_hero_units', (data: HeroUnitData[]) => {\n      updateLastReceived()\n      dispatch(setMinimapDataHeroUnits(data))\n    })\n    socket.on('STATUS', (data: MinimapStatusData) => {\n      updateLastReceived()\n      dispatch(setMinimapStatus(data))\n    })\n\n    socket.on('requestHeroData', async ({ allTime, heroId, steam32Id }, cb) => {\n      updateLastReceived()\n      const wl = { lose: 0, win: 0 }\n      const response = await fetcher(\n        `https://api.opendota.com/api/players/${steam32Id}/wl/?hero_id=${heroId}&having=1${\n          allTime ? '' : '&date=30'\n        }`,\n      )\n\n      if (response) {\n        wl.win = response.win\n        wl.lose = response.lose\n      }\n\n      cb(wl)\n    })\n\n    socket.on('requestMatchData', async ({ matchId, heroSlot }, cb) => {\n      updateLastReceived()\n      console.log('[MMR] requestMatchData event received', {\n        heroSlot,\n        matchId,\n      })\n      try {\n        // First check if we already have the match data cached\n        if (matchDataCache.has(matchId)) {\n          console.log('[MMR] Using cached match data for matchId:', matchId)\n          cb(matchDataCache.get(matchId))\n          return\n        }\n\n        // Try to get match data directly - the enhanced getMatchData will handle parsing if needed\n        console.log('[MMR] Fetching match data for matchId:', matchId, 'and heroSlot:', heroSlot)\n        const data = await getMatchData(matchId, heroSlot)\n        console.log('[MMR] Match data fetched:', data)\n        cb(data)\n      } catch (error) {\n        captureException(error)\n        console.log('[MMR] Error fetching match data', { error })\n        cb(null)\n      }\n    })\n\n    socket.on('block', (data: WireBlockType) => {\n      updateLastReceived()\n      const isMainScreenState = [\n        'DOTA_GAMERULES_STATE_INIT',\n        'DOTA_GAMERULES_STATE_POST_GAME',\n      ].includes(data.state ?? '')\n      const normalizedData: blockType =\n        data.type === 'empty' && isMainScreenState ? { ...data, type: null } : data\n\n      if (normalizedData.type === 'playing') {\n        setTimeout(() => {\n          setBlock(normalizedData)\n        }, 5000)\n      } else {\n        setBlock(normalizedData)\n      }\n    })\n    socket.on('paused', (data) => {\n      updateLastReceived()\n      setPaused(data)\n    })\n    socket.on('notable-players', (data) => {\n      updateLastReceived()\n      setNotablePlayers(data)\n    })\n    socket.on('aegis-picked-up', (data) => {\n      updateLastReceived()\n      setAegis(data)\n    })\n    socket.on('chatMessage', (data: ChatMessage) => {\n      updateLastReceived()\n      const messageWithTimestamp = {\n        ...data,\n        timestamp: data.timestamp ?? Date.now(),\n      }\n\n      // Add message to state\n      setChatMessages((prev: ChatMessage[]) => [...prev.slice(-7), messageWithTimestamp])\n\n      // Set up timeout to remove message after 10 seconds\n      const messageId = messageWithTimestamp.timestamp.toString()\n      const timeoutId = setTimeout(() => {\n        setChatMessages((prev: ChatMessage[]) =>\n          prev.filter((msg) => msg.timestamp?.toString() !== messageId),\n        )\n        messageTimeoutsRef.current.delete(messageId)\n        // 10 seconds\n      }, 10_000)\n\n      // Store timeout ID for cleanup\n      messageTimeoutsRef.current.set(messageId, timeoutId)\n    })\n    socket.on('roshan-killed', (data) => {\n      updateLastReceived()\n      setRoshan(data)\n    })\n    socket.on('auth_error', (message) => {\n      console.error('Authentication failed:', message)\n      socket?.disconnect()\n    })\n    socket.on('connect', () => {\n      console.log('Socket connected event fired')\n      updateLastReceived()\n      mutate()\n      setConnected(true)\n    })\n    socket.on('connect_error', (error) => {\n      console.error('Connection error event fired:', error)\n      setConnected(false)\n    })\n    socket.on('disconnect', (reason) => {\n      console.log('Socket disconnected event fired:', reason)\n      setConnected(false)\n    })\n\n    socket.on('refresh-settings', (_key: typeof Settings) => {\n      updateLastReceived()\n      mutate()\n    })\n\n    socket.on('channelPollOrBet', (data: PollData | BetData, eventName: string) => {\n      updateLastReceived()\n      console.log('twitchEvent', { data, eventName })\n      const isEnd = eventName.includes('End') || eventName.includes('Lock')\n      if (eventName.includes('Poll')) {\n        setPollData(isEnd || !('choices' in data) ? null : data)\n      } else {\n        setBetData(isEnd || !('outcomes' in data) ? null : data)\n      }\n    })\n\n    socket.on('update-medal', (deets: RankType) => {\n      updateLastReceived()\n      setRankImageDetails(getRankImage(deets))\n    })\n\n    socket.on(\n      'update-wl',\n      (\n        records: WLRecord[],\n        statsDays: number | null = null,\n        statsDaysTotal: number | null = null,\n      ) => {\n        updateLastReceived()\n        setWL({ records, statsDays, statsDaysTotal })\n      },\n    )\n\n    socket.on('update-radiant-win-chance', (chanceDetails: WinChance) => {\n      updateLastReceived()\n      // TODO: set setRadiantWinChance(null) on new match to avoid animation between matches\n      if (!chanceDetails) {\n        setRadiantWinChance((prev) => (prev ? { ...prev, visible: false } : null))\n        return\n      }\n      setRadiantWinChance({ ...chanceDetails, visible: true })\n    })\n\n    socket.on('refresh', () => {\n      updateLastReceived()\n      mutate()\n    })\n\n    // Clean up\n    return () => {\n      clearInterval(connectionMonitor)\n      clearInterval(diagnosticHeartbeat)\n      // Clear all message timeouts\n      messageTimeoutsRef.current.forEach((timeoutId) => {\n        clearTimeout(timeoutId)\n      })\n      messageTimeoutsRef.current.clear()\n\n      // Don't disconnect the socket on every effect cleanup\n      // Only clean up event handlers\n      socket?.off('connect')\n      socket?.off('connect_error')\n      socket?.off('disconnect')\n      socket?.off('DATA_buildings')\n      socket?.off('DATA_heroes')\n      socket?.off('DATA_couriers')\n      socket?.off('DATA_creeps')\n      socket?.off('DATA_hero_units')\n      socket?.off('STATUS')\n      socket?.off('requestHeroData')\n      socket?.off('requestMatchData')\n      socket?.off('block')\n      socket?.off('paused')\n      socket?.off('notable-players')\n      socket?.off('aegis-picked-up')\n      socket?.off('chatMessage')\n      socket?.off('roshan-killed')\n      socket?.off('auth_error')\n      socket?.off('refresh-settings')\n      socket?.off('channelPollOrBet')\n      socket?.off('update-medal')\n      socket?.off('update-wl')\n      socket?.off('update-radiant-win-chance')\n      socket?.off('refresh')\n    }\n    // Only depend on userId\n  }, [userId])",
-            "text": ""
-          }
-        ],
-        "message": "`on` creates a subscription in useEffect without guaranteed cleanup. Return a cleanup function that owns every allocation so it does not leak after unmount.",
-        "severity": "error"
-      }
-    },
     "1ca8ce6faeeeb0833341e062dac469e99cd5920355c3c79021cd07882bb2b729": {
       "count": 1,
       "summary": {
@@ -15749,6 +15680,26 @@
           }
         ],
         "message": "Unsafe call of a(n) `error` type typed value.",
+        "severity": "error"
+      }
+    },
+    "1d5652033f8e7ba14c7145fe4df88eac0ac4a2d43af02228d78c768469f445a2": {
+      "count": 1,
+      "summary": {
+        "code": "typescript(no-unsafe-type-assertion)",
+        "file": "src/pages/api/stripe/create-checkout.ts",
+        "labels": [
+          {
+            "context": {
+              "current": "const { priceId, paymentMethod } = (await req.body) as CheckoutRequestBody",
+              "next": "if (!priceId) {",
+              "previous": "// Parse and validate request body"
+            },
+            "span": "(await req.body) as CheckoutRequestBody",
+            "text": ""
+          }
+        ],
+        "message": "Unsafe assertion from `any` detected: consider using type guards or a safer assertion.",
         "severity": "error"
       }
     },
@@ -16298,6 +16249,35 @@
           }
         ],
         "message": "Unsafe array destructuring of a tuple element with an error typed value.",
+        "severity": "error"
+      }
+    },
+    "1eb8cf45fab6b52e3ebd097b95ec59e743df837418e330e6678c60018cf679f3": {
+      "count": 1,
+      "summary": {
+        "code": "eslint(no-use-before-define)",
+        "file": "src/pages/api/stripe/create-checkout.ts",
+        "labels": [
+          {
+            "context": {
+              "current": "return await createCryptoInvoice({",
+              "next": "customerId,",
+              "previous": "if (isCryptoPayment) {"
+            },
+            "span": "createCryptoInvoice",
+            "text": "used here"
+          },
+          {
+            "context": {
+              "current": "const createCryptoInvoice = async function createCryptoInvoice(",
+              "next": "params: Omit<CheckoutSessionParams, 'isCryptoPayment' | 'isTrialEligible'>,",
+              "previous": ""
+            },
+            "span": "createCryptoInvoice",
+            "text": "defined here"
+          }
+        ],
+        "message": "'createCryptoInvoice' was used before it was defined.",
         "severity": "error"
       }
     },
@@ -17872,6 +17852,26 @@
           }
         ],
         "message": "Unsafe assignment of an any value.",
+        "severity": "error"
+      }
+    },
+    "21ce816a189fdf54fdabde3dddabe2ccc63e000c32e697f921c9742102663323": {
+      "count": 1,
+      "summary": {
+        "code": "react-doctor(no-giant-component)",
+        "file": "src/components/Overlay/index.tsx",
+        "labels": [
+          {
+            "context": {
+              "current": "const OverlayPage = () => {",
+              "next": "const { notification } = App.useApp()",
+              "previous": ""
+            },
+            "span": "OverlayPage",
+            "text": ""
+          }
+        ],
+        "message": "Component \"OverlayPage\" is over 300 lines long, which is hard to read & change. Split it into a few smaller components.",
         "severity": "error"
       }
     },
@@ -20146,26 +20146,6 @@
           }
         ],
         "message": "Refactor this union type to have less than 3 elements.",
-        "severity": "error"
-      }
-    },
-    "25b77c4b1426887dbc22026f73ea8c6501e36c55b166ac2f178239881fc7d2f3": {
-      "count": 1,
-      "summary": {
-        "code": "vitest(require-mock-type-parameters)",
-        "file": "src/__tests__/pages/api/stripe/create-checkout.test.ts",
-        "labels": [
-          {
-            "context": {
-              "current": "findFirst: vi.fn().mockResolvedValue({ stripeCustomerId: 'cus_1' }),",
-              "next": "updateMany: vi.fn().mockResolvedValue({ count: 0 }),",
-              "previous": "subscription: {"
-            },
-            "span": "fn",
-            "text": ""
-          }
-        ],
-        "message": "Missing type parameters on mock function call",
         "severity": "error"
       }
     },
@@ -22870,26 +22850,6 @@
         "severity": "error"
       }
     },
-    "2ab872925ec4576b55e9033a7b42ff3c36565a2e22943b12a704d9b0ee3fde5f": {
-      "count": 1,
-      "summary": {
-        "code": "anti-slop(require-safety-comment-for-type-assertion)",
-        "file": "src/pages/api/stripe/create-checkout.ts",
-        "labels": [
-          {
-            "context": {
-              "current": "const { priceId, isGift, paymentMethod } = (await req.body) as CheckoutRequestBody",
-              "next": "if (!priceId) {",
-              "previous": "// Parse and validate request body"
-            },
-            "span": "(await req.body) as CheckoutRequestBody",
-            "text": ""
-          }
-        ],
-        "message": "This type assertion has no `SAFETY:` justification. State the checked invariant immediately before the assertion or its containing statement.",
-        "severity": "error"
-      }
-    },
     "2abf676f0b40a98138d0c80acbaffaa586668027a6faf74d0457cd6278efbbd1": {
       "count": 1,
       "summary": {
@@ -25379,26 +25339,6 @@
           }
         ],
         "message": "Unsafe assignment of an any value.",
-        "severity": "error"
-      }
-    },
-    "2f49e7968d99226f0445279132b88d2b0ea7a314980ee2d4c7e776d19ee03a2f": {
-      "count": 1,
-      "summary": {
-        "code": "typescript(no-unsafe-type-assertion)",
-        "file": "src/pages/api/stripe/create-checkout.ts",
-        "labels": [
-          {
-            "context": {
-              "current": "const { priceId, isGift, paymentMethod } = (await req.body) as CheckoutRequestBody",
-              "next": "if (!priceId) {",
-              "previous": "// Parse and validate request body"
-            },
-            "span": "(await req.body) as CheckoutRequestBody",
-            "text": ""
-          }
-        ],
-        "message": "Unsafe assertion from `any` detected: consider using type guards or a safer assertion.",
         "severity": "error"
       }
     },
@@ -32313,35 +32253,6 @@
         "severity": "error"
       }
     },
-    "3c909ef5bafd4a791fe69adfd6e916cd70681dfe1d1442a008e5c7b4274a292b": {
-      "count": 1,
-      "summary": {
-        "code": "eslint(no-use-before-define)",
-        "file": "src/pages/api/stripe/create-checkout.ts",
-        "labels": [
-          {
-            "context": {
-              "current": "const customerId = await ensureCustomer(session.user, tx)",
-              "next": "const subscriptionData = await getSubscription(session.user.id, tx)",
-              "previous": "async (tx) => {"
-            },
-            "span": "ensureCustomer",
-            "text": "used here"
-          },
-          {
-            "context": {
-              "current": "const ensureCustomer = async function ensureCustomer(",
-              "next": "user: {",
-              "previous": ""
-            },
-            "span": "ensureCustomer",
-            "text": "defined here"
-          }
-        ],
-        "message": "'ensureCustomer' was used before it was defined.",
-        "severity": "error"
-      }
-    },
     "3c9151a8736f23916a55c0662aff0a7a37913b4bcd7ae4c282fa11dca9590333": {
       "count": 1,
       "summary": {
@@ -38466,26 +38377,6 @@
         "severity": "error"
       }
     },
-    "47ca70ccfe953fc1c6b88fcdfc15db9b8dc6de98a4d780c1eea386ba875bc5ae": {
-      "count": 1,
-      "summary": {
-        "code": "vitest(require-mock-type-parameters)",
-        "file": "src/__tests__/pages/api/stripe/create-checkout.test.ts",
-        "labels": [
-          {
-            "context": {
-              "current": "invoiceItems: { create: vi.fn() },",
-              "next": "invoices: {",
-              "previous": "customers: { create: vi.fn(), list: vi.fn(), retrieve: vi.fn() },"
-            },
-            "span": "fn",
-            "text": ""
-          }
-        ],
-        "message": "Missing type parameters on mock function call",
-        "severity": "error"
-      }
-    },
     "47d04999d49a8cd575e9bdb878aec43e7b0523fd988a982d05f35450054b4aad": {
       "count": 1,
       "summary": {
@@ -41378,26 +41269,6 @@
         "severity": "error"
       }
     },
-    "4d72ad6f1c861d0e6ff17f69ac0e4a65297d70608219c46d60c2bf508c5094d6": {
-      "count": 1,
-      "summary": {
-        "code": "typescript(strict-boolean-expressions)",
-        "file": "src/pages/api/stripe/create-checkout.ts",
-        "labels": [
-          {
-            "context": {
-              "current": "isGift: isGift ? 'true' : 'false',",
-              "next": "isNewSubscription: isRecurring && !subscriptionData?.stripeSubscriptionId ? 'true' : 'false',",
-              "previous": "isCryptoPayment: 'false',"
-            },
-            "span": "isGift",
-            "text": ""
-          }
-        ],
-        "message": "Unexpected nullable boolean value in conditional. Please handle the nullish case explicitly.",
-        "severity": "error"
-      }
-    },
     "4d73fb4fb8729f94eb2b645061b93df355906a0230f9d1295bc499fb61b08777": {
       "count": 1,
       "summary": {
@@ -44038,26 +43909,6 @@
           }
         ],
         "message": "Missing type parameters on mock function call",
-        "severity": "error"
-      }
-    },
-    "52fc3d47ab3feac0ecd2b6662aab1e8ae7348b54d3f2b07983f80574494b5307": {
-      "count": 1,
-      "summary": {
-        "code": "sonarjs(cognitive-complexity)",
-        "file": "src/pages/api/stripe/create-checkout.ts",
-        "labels": [
-          {
-            "context": {
-              "current": "const createCryptoInvoice = async function createCryptoInvoice(",
-              "next": "params: Omit<CheckoutSessionParams, 'isGift' | 'isCryptoPayment' | 'isPaypalPayment'>,",
-              "previous": ""
-            },
-            "span": "function",
-            "text": ""
-          }
-        ],
-        "message": "Refactor this function to reduce its Cognitive Complexity from 22 to the 20 allowed.",
         "severity": "error"
       }
     },
@@ -49485,26 +49336,6 @@
         "severity": "error"
       }
     },
-    "5ef0a6db2d443251485bc5715b4835a60d20d6317ac6a2b17bfe3f98dc72efa1": {
-      "count": 1,
-      "summary": {
-        "code": "vitest(require-mock-type-parameters)",
-        "file": "src/__tests__/pages/api/stripe/create-checkout.test.ts",
-        "labels": [
-          {
-            "context": {
-              "current": "prices: { retrieve: vi.fn() },",
-              "next": "},",
-              "previous": "},"
-            },
-            "span": "fn",
-            "text": ""
-          }
-        ],
-        "message": "Missing type parameters on mock function call",
-        "severity": "error"
-      }
-    },
     "5efb87b4e76a913124d7ffde826255fbed5bf9687bc45b6b9d7c8881ba969f27": {
       "count": 1,
       "summary": {
@@ -49922,26 +49753,6 @@
           }
         ],
         "message": "Replace module mocking with dependency injection through a real interface, service layer, or faithful test implementation.",
-        "severity": "error"
-      }
-    },
-    "5fa399ef4900db6331839785f90cf7beb418cb619877ee4e10cb251aad0ce966": {
-      "count": 1,
-      "summary": {
-        "code": "typescript(strict-boolean-expressions)",
-        "file": "src/pages/api/stripe/create-checkout.ts",
-        "labels": [
-          {
-            "context": {
-              "current": "isNewSubscription: isRecurring && !subscriptionData?.stripeSubscriptionId ? 'true' : 'false',",
-              "next": "isUpgradeToLifetime: isLifetime && subscriptionData?.stripeSubscriptionId ? 'true' : 'false',",
-              "previous": "isGift: isGift ? 'true' : 'false',"
-            },
-            "span": "subscriptionData?.stripeSubscriptionId",
-            "text": ""
-          }
-        ],
-        "message": "Unexpected nullable string value in conditional. Please handle the nullish and empty string cases explicitly.",
         "severity": "error"
       }
     },
@@ -53221,26 +53032,6 @@
           }
         ],
         "message": "Replace module mocking with dependency injection through a real interface, service layer, or faithful test implementation.",
-        "severity": "error"
-      }
-    },
-    "664c45959ce0824e051ee2cf5e8246962f7a5bcc5d3d032fc377b28d3349ca1c": {
-      "count": 1,
-      "summary": {
-        "code": "sonarjs(no-redundant-assignments)",
-        "file": "src/pages/api/stripe/create-checkout.ts",
-        "labels": [
-          {
-            "context": {
-              "current": "trialDays = 0",
-              "next": "} else if (isInGracePeriod()) {",
-              "previous": "// No trial for gift purchases"
-            },
-            "span": "0",
-            "text": ""
-          }
-        ],
-        "message": "Review this redundant assignment: \"trialDays\" already holds the assigned value along all execution paths.",
         "severity": "error"
       }
     },
@@ -57083,26 +56874,6 @@
         "severity": "error"
       }
     },
-    "6d3cf082551e87c72dd0447d71634ebf5786225d6eeac89df292ddcdc5d4b0c9": {
-      "count": 1,
-      "summary": {
-        "code": "typescript(strict-boolean-expressions)",
-        "file": "src/pages/api/stripe/create-checkout.ts",
-        "labels": [
-          {
-            "context": {
-              "current": "if (isGift) {",
-              "next": "// No trial for gift purchases",
-              "previous": ""
-            },
-            "span": "isGift",
-            "text": ""
-          }
-        ],
-        "message": "Unexpected nullable boolean value in conditional. Please handle the nullish case explicitly.",
-        "severity": "error"
-      }
-    },
     "6d474cb51863cb9a06d126b90336698ed67d37e1c88bf3d233dcf63184ca8885": {
       "count": 1,
       "summary": {
@@ -58619,26 +58390,6 @@
         "severity": "error"
       }
     },
-    "70af40e3dbaea1df9ebcd79a24857b74482489a23947772158642aa961d26fc4": {
-      "count": 1,
-      "summary": {
-        "code": "sonarjs(no-nested-assignment)",
-        "file": "scripts/backfill-hubspot-contacts.ts",
-        "labels": [
-          {
-            "context": {
-              "current": "const user = users[(cursor += 1)]",
-              "next": "await syncUser(user)",
-              "previous": "while (cursor < users.length) {"
-            },
-            "span": "+=",
-            "text": ""
-          }
-        ],
-        "message": "Extract the assignment of \"cursor\" from this expression.",
-        "severity": "error"
-      }
-    },
     "70b2721f561d5984c578d5ed71b4f198e2b04192e6b5b1d061a53b9b4ffdad60": {
       "count": 1,
       "summary": {
@@ -59176,6 +58927,26 @@
           }
         ],
         "message": "Unsafe type assertion: type '\"admin\"' is more narrow than the original type.",
+        "severity": "error"
+      }
+    },
+    "7168af8262ec0b167eb5431e30a80aadfd8b4cba4800030fa53e9b70eeded898": {
+      "count": 1,
+      "summary": {
+        "code": "react-doctor(effect-needs-cleanup)",
+        "file": "src/lib/hooks/use-socket.tsx",
+        "labels": [
+          {
+            "context": {
+              "current": "useEffect(() => {",
+              "next": "if (!userId) {",
+              "previous": ""
+            },
+            "span": "useEffect(() => {\n    if (!userId) {\n      return\n    }\n\n    let lastReceivedTime = Date.now()\n\n    console.log('Connecting to socket init...', { userId })\n\n    // Create socket connection only once per userId\n    if (!socket) {\n      socket = io(process.env.NEXT_PUBLIC_GSI_WEBSOCKET_URL, {\n        auth: { token: userId },\n        reconnection: true,\n        reconnectionAttempts: Number.POSITIVE_INFINITY,\n        reconnectionDelay: 1000,\n        reconnectionDelayMax: 5000,\n        timeout: 20_000,\n      })\n\n      console.log('Socket instance created:', Boolean(socket))\n    }\n    const activeSocket = socket\n\n    // Use socket.io's built-in ping event to track connection health\n    socket.io.on('ping', () => {\n      lastReceivedTime = Date.now()\n    })\n\n    // Monitor for stale connections\n    const connectionMonitor = setInterval(() => {\n      if (Date.now() - lastReceivedTime > 45_000) {\n        // 45s = 3 missed pings\n        console.log('Connection appears stale, reconnecting...')\n        socket?.disconnect()\n        socket?.connect()\n      }\n    }, 15_000)\n\n    const diagnosticHeartbeat = setInterval(() => {\n      if (socket?.connected) {\n        socket.emit('diagnostic-heartbeat')\n      }\n    }, 60_000)\n\n    // Update lastReceivedTime whenever we get any data\n    const updateLastReceived = () => {\n      lastReceivedTime = Date.now()\n    }\n\n    // Add handlers for all existing events\n    socket.on('DATA_buildings', (data) => {\n      updateLastReceived()\n      dispatch(setMinimapDataBuildings(data))\n    })\n\n    socket.on('DATA_heroes', (data) => {\n      updateLastReceived()\n      dispatch(setMinimapDataHeroes(data))\n    })\n\n    socket.on('DATA_couriers', (data: CourierData[]) => {\n      updateLastReceived()\n      dispatch(setMinimapDataCouriers(data))\n    })\n\n    socket.on('DATA_creeps', (data: CreepData[]) => {\n      updateLastReceived()\n      dispatch(setMinimapDataCreeps(data))\n    })\n    socket.on('DATA_hero_units', (data: HeroUnitData[]) => {\n      updateLastReceived()\n      dispatch(setMinimapDataHeroUnits(data))\n    })\n    socket.on('STATUS', (data: MinimapStatusData) => {\n      updateLastReceived()\n      dispatch(setMinimapStatus(data))\n    })\n\n    socket.on('requestHeroData', async ({ allTime, heroId, steam32Id }, cb) => {\n      updateLastReceived()\n      const wl = { lose: 0, win: 0 }\n      const response = await fetcher(\n        `https://api.opendota.com/api/players/${steam32Id}/wl/?hero_id=${heroId}&having=1${\n          allTime ? '' : '&date=30'\n        }`,\n      )\n\n      if (response) {\n        wl.win = response.win\n        wl.lose = response.lose\n      }\n\n      cb(wl)\n    })\n\n    socket.on('requestMatchData', async ({ matchId, heroSlot }, cb) => {\n      updateLastReceived()\n      console.log('[MMR] requestMatchData event received', {\n        heroSlot,\n        matchId,\n      })\n      try {\n        // First check if we already have the match data cached\n        if (matchDataCache.has(matchId)) {\n          console.log('[MMR] Using cached match data for matchId:', matchId)\n          cb(matchDataCache.get(matchId))\n          return\n        }\n\n        // Try to get match data directly - the enhanced getMatchData will handle parsing if needed\n        console.log('[MMR] Fetching match data for matchId:', matchId, 'and heroSlot:', heroSlot)\n        const data = await getMatchData(matchId, heroSlot)\n        console.log('[MMR] Match data fetched:', data)\n        cb(data)\n      } catch (error) {\n        captureException(error)\n        console.log('[MMR] Error fetching match data', { error })\n        cb(null)\n      }\n    })\n\n    socket.on('block', (data: WireBlockType) => {\n      updateLastReceived()\n      const isMainScreenState = [\n        'DOTA_GAMERULES_STATE_INIT',\n        'DOTA_GAMERULES_STATE_POST_GAME',\n      ].includes(data.state ?? '')\n      const normalizedData: blockType =\n        data.type === 'empty' && isMainScreenState ? { ...data, type: null } : data\n\n      if (normalizedData.type === 'playing') {\n        setTimeout(() => {\n          setBlock(normalizedData)\n        }, 5000)\n      } else {\n        setBlock(normalizedData)\n      }\n    })\n    socket.on('paused', (data) => {\n      updateLastReceived()\n      setPaused(data)\n    })\n    socket.on('notable-players', (data) => {\n      updateLastReceived()\n      setNotablePlayers(data)\n    })\n    socket.on('aegis-picked-up', (data) => {\n      updateLastReceived()\n      setAegis(data)\n    })\n    socket.on('chatMessage', (data: ChatMessage) => {\n      updateLastReceived()\n      const messageWithTimestamp = {\n        ...data,\n        timestamp: data.timestamp ?? Date.now(),\n      }\n\n      // Add message to state\n      setChatMessages((prev: ChatMessage[]) => [...prev.slice(-7), messageWithTimestamp])\n\n      // Set up timeout to remove message after 10 seconds\n      const messageId = messageWithTimestamp.timestamp.toString()\n      const timeoutId = setTimeout(() => {\n        setChatMessages((prev: ChatMessage[]) =>\n          prev.filter((msg) => msg.timestamp?.toString() !== messageId),\n        )\n        messageTimeoutsRef.current.delete(messageId)\n        // 10 seconds\n      }, 10_000)\n\n      // Store timeout ID for cleanup\n      messageTimeoutsRef.current.set(messageId, timeoutId)\n    })\n    socket.on('roshan-killed', (data) => {\n      updateLastReceived()\n      setRoshan(data)\n    })\n    socket.on('auth_error', (message) => {\n      console.error('Authentication failed:', message)\n      socket?.disconnect()\n    })\n    socket.on('connect', () => {\n      console.log('Socket connected event fired')\n      updateLastReceived()\n      mutate()\n      setConnected(true)\n    })\n    socket.on('connect_error', (error) => {\n      console.error('Connection error event fired:', error)\n      setConnected(false)\n    })\n    socket.on('disconnect', (reason) => {\n      console.log('Socket disconnected event fired:', reason)\n      setConnected(false)\n    })\n\n    socket.on('refresh-settings', (_key: typeof Settings) => {\n      updateLastReceived()\n      mutate()\n    })\n\n    activeSocket.on('diagnostic-overlay-probe', () => {\n      updateLastReceived()\n      handleOverlayDiagnosticProbe(userId)\n    })\n\n    socket.on('channelPollOrBet', (data: PollData | BetData, eventName: string) => {\n      updateLastReceived()\n      console.log('twitchEvent', { data, eventName })\n      const isEnd = eventName.includes('End') || eventName.includes('Lock')\n      if (eventName.includes('Poll')) {\n        setPollData(isEnd || !('choices' in data) ? null : data)\n      } else {\n        setBetData(isEnd || !('outcomes' in data) ? null : data)\n      }\n    })\n\n    socket.on('update-medal', (deets: RankType) => {\n      updateLastReceived()\n      setRankImageDetails(getRankImage(deets))\n    })\n\n    socket.on(\n      'update-wl',\n      (\n        records: WLRecord[],\n        statsDays: number | null = null,\n        statsDaysTotal: number | null = null,\n      ) => {\n        updateLastReceived()\n        setWL({ records, statsDays, statsDaysTotal })\n      },\n    )\n\n    socket.on('update-radiant-win-chance', (chanceDetails: WinChance) => {\n      updateLastReceived()\n      // TODO: set setRadiantWinChance(null) on new match to avoid animation between matches\n      if (!chanceDetails) {\n        setRadiantWinChance((prev) => (prev ? { ...prev, visible: false } : null))\n        return\n      }\n      setRadiantWinChance({ ...chanceDetails, visible: true })\n    })\n\n    socket.on('refresh', () => {\n      updateLastReceived()\n      mutate()\n    })\n\n    // Clean up\n    return () => {\n      clearInterval(connectionMonitor)\n      clearInterval(diagnosticHeartbeat)\n      // Clear all message timeouts\n      messageTimeoutsRef.current.forEach((timeoutId) => {\n        clearTimeout(timeoutId)\n      })\n      messageTimeoutsRef.current.clear()\n\n      // Don't disconnect the socket on every effect cleanup\n      // Only clean up event handlers\n      socket?.off('connect')\n      socket?.off('connect_error')\n      socket?.off('disconnect')\n      socket?.off('DATA_buildings')\n      socket?.off('DATA_heroes')\n      socket?.off('DATA_couriers')\n      socket?.off('DATA_creeps')\n      socket?.off('DATA_hero_units')\n      socket?.off('STATUS')\n      socket?.off('requestHeroData')\n      socket?.off('requestMatchData')\n      socket?.off('block')\n      socket?.off('paused')\n      socket?.off('notable-players')\n      socket?.off('aegis-picked-up')\n      socket?.off('chatMessage')\n      socket?.off('roshan-killed')\n      socket?.off('auth_error')\n      socket?.off('refresh-settings')\n      activeSocket.off('diagnostic-overlay-probe')\n      socket?.off('channelPollOrBet')\n      socket?.off('update-medal')\n      socket?.off('update-wl')\n      socket?.off('update-radiant-win-chance')\n      socket?.off('refresh')\n    }\n  }, [\n    dispatch,\n    mutate,\n    setAegis,\n    setBetData,\n    setBlock,\n    setChatMessages,\n    setConnected,\n    setNotablePlayers,\n    setPaused,\n    setPollData,\n    setRadiantWinChance,\n    setRankImageDetails,\n    setRoshan,\n    setWL,\n    userId,\n  ])",
+            "text": ""
+          }
+        ],
+        "message": "`on` creates a subscription in useEffect without guaranteed cleanup. Return a cleanup function that owns every allocation so it does not leak after unmount.",
         "severity": "error"
       }
     },
@@ -66682,26 +66453,6 @@
         "severity": "error"
       }
     },
-    "7fd6717b80d95fb09fdd0bac3c6eb409a275e17bad4f1f1d0bb4fb1e5af6edae": {
-      "count": 1,
-      "summary": {
-        "code": "vitest(require-mock-type-parameters)",
-        "file": "src/__tests__/pages/api/stripe/create-checkout.test.ts",
-        "labels": [
-          {
-            "context": {
-              "current": "updateMany: vi.fn().mockResolvedValue({ count: 0 }),",
-              "next": "},",
-              "previous": "findFirst: vi.fn().mockResolvedValue({ stripeCustomerId: 'cus_1' }),"
-            },
-            "span": "fn",
-            "text": ""
-          }
-        ],
-        "message": "Missing type parameters on mock function call",
-        "severity": "error"
-      }
-    },
     "7feba1ae6130864d9d94684dd8b8b6d543fdb6b298416f4f1450f10218687138": {
       "count": 1,
       "summary": {
@@ -70472,26 +70223,6 @@
         "severity": "error"
       }
     },
-    "871049da2ab5ae548c1c5db70c396c05a68a0d03fb00e3a590d99275cc57ab86": {
-      "count": 1,
-      "summary": {
-        "code": "unicorn(no-useless-undefined)",
-        "file": "src/__tests__/pages/api/hubspot/visitor-token.test.ts",
-        "labels": [
-          {
-            "context": {
-              "current": "vi.mocked(syncHubSpotContact).mockResolvedValue(undefined)",
-              "next": "vi.mocked(subscriptionToValue).mockReturnValue('pro')",
-              "previous": "vi.mocked(fetch).mockResolvedValue(tokenOk())"
-            },
-            "span": "undefined",
-            "text": ""
-          }
-        ],
-        "message": "Do not use useless `undefined`.",
-        "severity": "error"
-      }
-    },
     "87325d8bfab9ee82c23a6916853336e3c1ae3ed0e22ea25542bd70485d075c6d": {
       "count": 1,
       "summary": {
@@ -72196,26 +71927,6 @@
           }
         ],
         "message": "Functions that return promises must be async.",
-        "severity": "error"
-      }
-    },
-    "8a7318b8fdbfa05200f551d0d847a6c2b2c15763e1f2a079b38cc366c2382f9f": {
-      "count": 1,
-      "summary": {
-        "code": "vitest(require-mock-type-parameters)",
-        "file": "src/__tests__/pages/api/stripe/create-checkout.test.ts",
-        "labels": [
-          {
-            "context": {
-              "current": "checkout: { sessions: { create: vi.fn() } },",
-              "next": "customers: { create: vi.fn(), list: vi.fn(), retrieve: vi.fn() },",
-              "previous": "stripe: {"
-            },
-            "span": "fn",
-            "text": ""
-          }
-        ],
-        "message": "Missing type parameters on mock function call",
         "severity": "error"
       }
     },
@@ -74419,6 +74130,26 @@
           }
         ],
         "message": "Missing type parameters on mock function call",
+        "severity": "error"
+      }
+    },
+    "8ed14d0167332d128e4536d11130852c874fe65e287412499bc1ef8a820eee54": {
+      "count": 1,
+      "summary": {
+        "code": "eslint(no-await-in-loop)",
+        "file": "scripts/backfill-hubspot-contacts.ts",
+        "labels": [
+          {
+            "context": {
+              "current": "await syncUser(user)",
+              "next": "}",
+              "previous": "cursor += 1"
+            },
+            "span": "await",
+            "text": ""
+          }
+        ],
+        "message": "Unexpected `await` inside a loop.",
         "severity": "error"
       }
     },
@@ -83107,26 +82838,6 @@
         "severity": "error"
       }
     },
-    "9f9af9472619078dadb2ad17f8af46602aee37b069f55c6c69d45109fb70911c": {
-      "count": 1,
-      "summary": {
-        "code": "react-doctor(no-giant-component)",
-        "file": "src/components/Overlay/index.tsx",
-        "labels": [
-          {
-            "context": {
-              "current": "const OverlayPage = () => {",
-              "next": "const router = useRouter()",
-              "previous": ""
-            },
-            "span": "OverlayPage",
-            "text": ""
-          }
-        ],
-        "message": "Component \"OverlayPage\" is over 300 lines long, which is hard to read & change. Split it into a few smaller components.",
-        "severity": "error"
-      }
-    },
     "9f9bfc288fe9b26787dc7ba65dfe4689147f7eba6d8615da4f447e5560587940": {
       "count": 1,
       "summary": {
@@ -86121,26 +85832,6 @@
         "severity": "error"
       }
     },
-    "a509ce6b3e614c504fc766dad693c88f3e0db5941d2d12e6018dddee2fa79fe8": {
-      "count": 1,
-      "summary": {
-        "code": "eslint(complexity)",
-        "file": "src/pages/api/stripe/create-checkout.ts",
-        "labels": [
-          {
-            "context": {
-              "current": "const createCryptoInvoice = async function createCryptoInvoice(",
-              "next": "params: Omit<CheckoutSessionParams, 'isGift' | 'isCryptoPayment' | 'isPaypalPayment'>,",
-              "previous": ""
-            },
-            "span": "async function createCryptoInvoice(\n  params: Omit<CheckoutSessionParams, 'isGift' | 'isCryptoPayment' | 'isPaypalPayment'>,\n): Promise<string> {\n  const {\n    customerId,\n    priceId,\n    isRecurring,\n    isLifetime,\n    subscriptionData,\n    userId,\n    email,\n    name,\n    image,\n    locale,\n    twitchId,\n  } = params\n\n  // Cancel any pending crypto invoices if this is an upgrade\n  if (subscriptionData?.stripePriceId) {\n    try {\n      const existingSubscription = await prisma.subscription.findFirst({\n        select: { metadata: true },\n        where: {\n          NOT: { status: 'CANCELED' },\n          stripeCustomerId: customerId,\n          userId,\n        },\n      })\n\n      const metadata = (existingSubscription?.metadata as Record<string, unknown>) || {}\n      const renewalInvoiceId = metadata.renewalInvoiceId as string\n\n      if (renewalInvoiceId) {\n        console.log(`Canceling pending invoice ${renewalInvoiceId} for user ${userId}`)\n        try {\n          await stripe.invoices.voidInvoice(renewalInvoiceId)\n        } catch {\n          try {\n            const invoice = await stripe.invoices.retrieve(renewalInvoiceId)\n            if (invoice.status === 'open') {\n              await stripe.invoices.markUncollectible(renewalInvoiceId)\n            }\n          } catch (markError) {\n            console.error(`Failed to handle invoice ${renewalInvoiceId}:`, markError)\n          }\n        }\n      }\n    } catch (error) {\n      console.error('Error canceling pending invoices:', error)\n    }\n  }\n\n  const { getCurrentPeriod } = await import('@/utils/subscription')\n  const pricePeriod = getCurrentPeriod(priceId)\n  const price = await stripe.prices.retrieve(priceId)\n\n  if (!price.unit_amount) {\n    throw new Error('Price has no unit amount')\n  }\n\n  const dueDate = new Date()\n  dueDate.setDate(dueDate.getDate() + 7)\n\n  const invoiceParams: Stripe.InvoiceCreateParams = {\n    collection_method: 'send_invoice',\n    customer: customerId,\n    due_date: Math.floor(dueDate.getTime() / 1000),\n    metadata: {\n      email,\n      image,\n      isCryptoPayment: 'true',\n      isNewSubscription: isRecurring && !subscriptionData?.stripeSubscriptionId ? 'true' : 'false',\n      isUpgradeToLifetime: isLifetime && subscriptionData?.stripeSubscriptionId ? 'true' : 'false',\n      locale,\n      name,\n      paymentProvider: 'nowpayments',\n      previousSubscriptionId: subscriptionData?.stripeSubscriptionId ?? '',\n      pricePeriod,\n      stripePriceId: priceId,\n      twitchId,\n      userId,\n    },\n    payment_settings: {\n      payment_method_types: [],\n    },\n  }\n\n  const stripeInvoice = await stripe.invoices.create(invoiceParams)\n  if (!stripeInvoice?.id) {\n    throw new Error('Stripe invoice creation failed')\n  }\n\n  await stripe.invoiceItems.create({\n    customer: customerId,\n    invoice: stripeInvoice.id,\n    price_data: {\n      currency: price.currency,\n      product: price.product as string,\n      unit_amount: price.unit_amount,\n    },\n  })\n\n  const finalized = await stripe.invoices.finalizeInvoice(stripeInvoice.id, {\n    auto_advance: false,\n  })\n\n  const { url, nowPaymentsId } = await createAndStoreCryptoInvoice({\n    metadata: { pricePeriod, stripePriceId: priceId },\n    orderDescription: `Dotabod ${pricePeriod} subscription`,\n    stripeInvoice: finalized,\n    userId,\n  })\n\n  await stripe.invoices.update(stripeInvoice.id, {\n    metadata: {\n      ...invoiceParams.metadata,\n      nowpayments_invoice_id: nowPaymentsId,\n      nowpayments_invoice_url: url,\n    },\n  })\n\n  return url\n}",
-            "text": ""
-          }
-        ],
-        "message": "async function `createCryptoInvoice` has a complexity of 21. Maximum allowed is 20.",
-        "severity": "error"
-      }
-    },
     "a50e1840d8f5f1623959546a0d1a5f012b94db70f6b54a7472ba86ace19dca82": {
       "count": 1,
       "summary": {
@@ -86416,6 +86107,26 @@
           }
         ],
         "message": "Unsafe member access ._getJSONData on an `error` typed value.",
+        "severity": "error"
+      }
+    },
+    "a57820a5c2998c7445f56be65b0a0aa85a1bbd8ae683ffc903046807d95598dd": {
+      "count": 1,
+      "summary": {
+        "code": "eslint(complexity)",
+        "file": "src/pages/[username].tsx",
+        "labels": [
+          {
+            "context": {
+              "current": "const PageContent = ({",
+              "next": "userData: ssrUserData,",
+              "previous": ""
+            },
+            "span": "({\n  userData: ssrUserData,\n  subscriptionInfo: ssrSubscriptionInfo,\n  username: ssrUsername,\n  collection,\n  heroPerformance = [],\n  recentMatches = [],\n}: PageContentProps = {}) => {\n  const [permission, setPermission] = useState('All')\n  const [enabled, setEnabled] = useState('All')\n  const [searchTerm, setSearchTerm] = useState('')\n  const [openCardKey, setOpenCardKey] = useState<string | null>(null)\n  const router = useRouter()\n  const { username } = router.query\n  const { data, loading, error, notFound } = useGetSettingsByUsername()\n\n  const shouldFetchSub = !ssrSubscriptionInfo && typeof username === 'string' && Boolean(username)\n  const { data: subData, isLoading: subLoading } = useSWR<{\n    isPro?: boolean\n    isLifetime?: boolean\n    isGracePeriodPro?: boolean\n    inGracePeriod?: boolean\n  }>(shouldFetchSub ? `/api/subscription/by-username?username=${username}` : null, fetcher)\n\n  const subscriptionInfo = {\n    inGracePeriod: ssrSubscriptionInfo?.inGracePeriod ?? subData?.inGracePeriod ?? false,\n    isGracePeriodPro: ssrSubscriptionInfo?.isGracePeriodPro ?? subData?.isGracePeriodPro ?? false,\n    isLifetime: ssrSubscriptionInfo?.isLifetime ?? subData?.isLifetime ?? false,\n    isPro: ssrSubscriptionInfo?.isPro ?? subData?.isPro ?? false,\n    loading: shouldFetchSub ? subLoading : false,\n  }\n\n  // Use SSR data if available, otherwise fall back to client-side data\n  const finalUserData = ssrUserData ?? data\n  const finalLoading = ssrUserData ? false : loading\n  const profile = finalUserData as {\n    displayName?: string | null\n    name?: string\n    stream_online?: boolean\n    image?: string | null\n    createdAt?: string\n    mmr?: number\n    twitchId?: string | null\n    settings?: { key: string; value: unknown }[]\n    error?: unknown\n  }\n\n  useEffect(() => {\n    // Only redirect to 404 if username exists in query and we've finished loading (for client-side only)\n    if (!ssrUserData && username && !finalLoading && (notFound || profile?.error || error)) {\n      void router.push('/404')\n    }\n  }, [finalLoading, profile, router, notFound, error, username, ssrUserData])\n\n  if (finalLoading || error || !finalUserData) {\n    return (\n      <div className='p-6'>\n        <div className='mb-12 space-y-4'>\n          <div className='flex flex-row items-center space-x-2'>\n            <Skeleton.Avatar active size={80} shape='circle' />\n            <div className='flex-grow'>\n              <div className='flex flex-row items-center space-x-4'>\n                <Skeleton.Button active size='large' shape='round' />\n                <Skeleton.Button active size='small' shape='round' style={{ width: 60 }} />\n              </div>\n              <Skeleton.Input active size='small' style={{ marginTop: 8, width: 200 }} />\n            </div>\n            <div>\n              <div className='flex space-x-2'>\n                <Skeleton.Button active size='default' shape='default' style={{ width: 140 }} />\n                <Skeleton.Button active size='default' shape='default' style={{ width: 160 }} />\n              </div>\n            </div>\n          </div>\n          <Skeleton active paragraph={{ rows: 1 }} />\n        </div>\n\n        <div className='mb-4 flex max-w-full flex-wrap items-baseline gap-2 sm:gap-6'>\n          <Skeleton.Button active size='default' shape='default' style={{ width: 200 }} />\n          <Skeleton.Button active size='default' shape='default' style={{ width: 200 }} />\n          <Skeleton.Input active size='default' style={{ width: 300 }} />\n        </div>\n\n        <div className='mb-10 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-4'>\n          {['sk1', 'sk2', 'sk3', 'sk4', 'sk5', 'sk6', 'sk7', 'sk8'].map((key) => (\n            <div key={key} className='rounded-lg border border-gray-700 p-4'>\n              <Skeleton active paragraph={{ rows: 3 }} />\n            </div>\n          ))}\n        </div>\n      </div>\n    )\n  }\n\n  const commands = profile?.settings\n    ? commandKeys.map((command) => {\n        const commandDetail = CommandDetail[command]\n        const isEnabled = getValueOrDefault(commandDetail.key, profile.settings)\n        return { command, isEnabled: Boolean(isEnabled) }\n      })\n    : []\n\n  const filteredCommands = commandKeys\n    .filter((command) => {\n      const commandDetail = CommandDetail[command]\n      const isEnabled = getValueOrDefault(commandDetail.key, profile.settings)\n      if (enabled === 'Enabled') {\n        return isEnabled === true\n      }\n      if (enabled === 'Disabled') {\n        return isEnabled === false\n      }\n      return true\n    })\n    .filter((command) => {\n      const commandDetail = CommandDetail[command]\n      if (permission === 'Mods') {\n        return commandDetail.allowed === 'mods'\n      }\n      if (permission === 'Viewers') {\n        return commandDetail.allowed === 'all'\n      }\n      return true\n    })\n    .filter((command) => {\n      const keysToSearch = ['alias', 'title', 'description', 'cmd']\n      const commandDetail = CommandDetail[command]\n      return keysToSearch.some((key) => {\n        const value = commandDetail[key as keyof typeof commandDetail] ?? ''\n        if (Array.isArray(value)) {\n          return value.some(\n            (alias) =>\n              alias.toLowerCase().includes(searchTerm) ||\n              `!${alias.toLowerCase()}`.includes(searchTerm),\n          )\n        }\n        return typeof value === 'string' && value.toLowerCase().includes(searchTerm)\n      })\n    })\n\n  const enabledFeaturedCommands = FEATURED_COMMAND_KEYS.filter(\n    (key) => commands.find((c) => c.command === key)?.isEnabled,\n  )\n\n  // Determine what subscription badge to show\n  const getSubscriptionBadge = () => {\n    if (subscriptionInfo.loading) {\n      return null\n    }\n    if (subscriptionInfo.isPro) {\n      if (subscriptionInfo.isGracePeriodPro) {\n        return (\n          <Tooltip title='Using Pro features during free trial period'>\n            <Tag color='blue' className='flex! items-center gap-1 py-0.5'>\n              <CrownIcon size={14} className='inline-block flex-shrink-0' />\n              <span>Free Trial</span>\n            </Tag>\n          </Tooltip>\n        )\n      }\n\n      if (subscriptionInfo.isLifetime) {\n        return (\n          <Tooltip title='Lifetime Pro Subscriber'>\n            <Tag color='gold' className='flex! items-center gap-1 py-0.5'>\n              <CrownIcon size={14} className='inline-block flex-shrink-0' />\n              <span>Lifetime Pro</span>\n            </Tag>\n          </Tooltip>\n        )\n      }\n\n      return (\n        <Tooltip title='Pro Subscriber'>\n          <Tag color='gold' className='flex! items-center gap-1 py-0.5'>\n            <CrownIcon size={14} className='inline-block flex-shrink-0' />\n            <span>Pro</span>\n          </Tag>\n        </Tooltip>\n      )\n    }\n\n    return null\n  }\n\n  return (\n    <>\n      {/* oxlint-disable-next-line nextjs/no-duplicate-head -- conditional render path, only one Head per render */}\n      <Head>\n        <title>{`${finalLoading || !profile?.displayName ? '...' : profile.displayName}'s Dota 2 Commands — Dotabod`}</title>\n        <meta\n          name='description'\n          content={`Chat commands available in ${profile?.displayName ?? 'this streamer'}'s Twitch channel via Dotabod.`}\n        />\n        {username && typeof username === 'string' && (\n          <link rel='canonical' href={`https://dotabod.com/${username}`} />\n        )}\n        <meta\n          name='robots'\n          content={username === '[username]' ? 'noindex, nofollow' : 'index, follow'}\n        />\n      </Head>\n\n      {/* Full-width hero */}\n      <div className='relative border-b border-gray-700/50 bg-gradient-to-br from-gray-950 to-gray-800'>\n        <Container className='py-10 sm:py-14'>\n          <div className='flex flex-col gap-6 sm:flex-row sm:flex-wrap sm:items-start sm:gap-10 lg:flex-nowrap'>\n            {/* Avatar with live ring */}\n            <div className='relative flex-shrink-0 self-start'>\n              <div\n                className={`absolute -inset-1.5 rounded-full ${\n                  profile?.stream_online ? 'animate-pulse bg-red-500/30' : 'bg-gray-600/10'\n                }`}\n              />\n              <img\n                onError={(e) => {\n                  e.currentTarget.src = '/images/hero/default.png'\n                }}\n                src={profile?.image ?? '/images/hero/default.png'}\n                alt='Profile'\n                width={100}\n                height={100}\n                className='relative rounded-full ring-2 ring-gray-700'\n              />\n              {profile?.stream_online && (\n                <span className='absolute -bottom-1 left-1/2 -translate-x-1/2 rounded-full bg-red-600 px-2 py-px text-[10px] font-bold tracking-wide text-white uppercase'>\n                  Live\n                </span>\n              )}\n            </div>\n\n            {/* Identity, stats, CTAs */}\n            <div className='min-w-0 flex-grow'>\n              <div className='mb-1 flex flex-wrap items-center gap-2'>\n                <h1 className='text-3xl font-bold text-white sm:text-4xl'>\n                  {finalLoading || !profile?.displayName ? 'Loading...' : profile.displayName}\n                </h1>\n                {!profile?.stream_online && (\n                  <span className='rounded-md bg-gray-700 px-2 py-0.5 text-xs text-gray-400'>\n                    Offline\n                  </span>\n                )}\n                {getSubscriptionBadge()}\n              </div>\n\n              <div className='mb-6 flex flex-wrap gap-x-5 gap-y-1 text-sm text-gray-400'>\n                {profile?.mmr !== null && profile?.mmr !== undefined && profile.mmr > 0 && (\n                  <span>⚔ {profile.mmr.toLocaleString()} MMR</span>\n                )}\n                <LiveProfileWinLossCounter\n                  isLive={profile.stream_online === true}\n                  twitchId={profile?.twitchId}\n                />\n                <span>\n                  Using Dotabod since{' '}\n                  {finalLoading || !profile?.createdAt\n                    ? '...'\n                    : new Date(profile.createdAt).toLocaleDateString('en-US', {\n                        month: 'long',\n                        year: 'numeric',\n                      })}\n                </span>\n                {!finalLoading && commands.length > 0 && (\n                  <span>{commands.filter((c) => c.isEnabled).length} commands active</span>\n                )}\n              </div>\n\n              <div className='flex flex-wrap gap-3'>\n                <Link\n                  target='_blank'\n                  href={profile ? `https://twitch.tv/${profile.name}` : ''}\n                  passHref\n                >\n                  <Button\n                    size='large'\n                    icon={<ExternalLinkIcon size={16} />}\n                    className='flex items-center'\n                  >\n                    Watch on Twitch\n                  </Button>\n                </Link>\n                <Link\n                  href={createGiftLink(\n                    ssrUsername ?? (typeof username === 'string' ? username : ''),\n                  )}\n                  passHref\n                >\n                  <Button\n                    type='primary'\n                    size='large'\n                    icon={<GiftIcon size={16} />}\n                    className='flex items-center'\n                  >\n                    Gift Subscription\n                  </Button>\n                </Link>\n                <Link\n                  href={getProfileRoute(\n                    ssrUsername ?? (typeof username === 'string' ? username : undefined),\n                    '/matches',\n                  )}\n                  passHref\n                >\n                  <Button\n                    size='large'\n                    icon={<BarChart3Icon size={16} />}\n                    className='flex items-center'\n                  >\n                    Match history\n                  </Button>\n                </Link>\n              </div>\n            </div>\n\n            {collection && collection.count > 0 ? (\n              <FannedHand\n                username={ssrUsername ?? (typeof username === 'string' ? username : '')}\n                collection={collection}\n              />\n            ) : (\n              <CollectionTeaser\n                username={ssrUsername ?? (typeof username === 'string' ? username : '')}\n                name={profile?.displayName ?? profile?.name ?? 'this streamer'}\n              />\n            )}\n          </div>\n        </Container>\n      </div>\n\n      {/* Page content */}\n      <Container className='py-8'>\n        <ProfileMatchOverview\n          heroPerformance={heroPerformance}\n          recentMatches={recentMatches}\n          username={ssrUsername ?? (typeof username === 'string' ? username : '')}\n        />\n\n        {/* Featured commands strip */}\n        {!finalLoading && enabledFeaturedCommands.length > 0 && (\n          <div className='mb-10'>\n            <p className='mb-3 text-xs font-semibold tracking-widest text-gray-500 uppercase'>\n              Popular commands\n            </p>\n            <div className='-mx-1 flex gap-3 overflow-x-auto px-1 pb-2'>\n              {enabledFeaturedCommands.map((key) => (\n                <button\n                  key={key}\n                  type='button'\n                  onClick={() => {\n                    setOpenCardKey(key)\n                    setTimeout(() => {\n                      document\n                        .getElementById(`command-card-${key}`)\n                        ?.scrollIntoView({ behavior: 'smooth', block: 'center' })\n                    }, 50)\n                  }}\n                  className='w-48 flex-shrink-0 cursor-pointer rounded-lg border border-gray-700 bg-gray-900/80 px-4 py-3 text-left transition-colors hover:border-purple-500 hover:bg-gray-900'\n                >\n                  <div className='mb-1 font-mono text-sm font-semibold text-purple-400'>\n                    {CommandDetail[key].cmd}\n                  </div>\n                  <div className='line-clamp-2 text-xs text-gray-400'>\n                    {CommandDetail[key].description}\n                  </div>\n                </button>\n              ))}\n            </div>\n          </div>\n        )}\n\n        {/* Filter bar */}\n        <div className='mb-6 flex flex-wrap items-center gap-3'>\n          <Segmented\n            value={enabled}\n            onChange={(v) => {\n              setEnabled(v)\n            }}\n            options={['All', 'Enabled', 'Disabled']}\n          />\n          <Segmented\n            value={permission}\n            onChange={(v) => {\n              setPermission(v)\n            }}\n            options={['All', 'Mods', 'Viewers']}\n          />\n          <Input\n            placeholder='Search commands...'\n            value={searchTerm}\n            maxLength={200}\n            style={{ width: 260 }}\n            onChange={(e) => {\n              setSearchTerm(e.target.value.toLowerCase())\n            }}\n          />\n          {!finalLoading && (\n            <span className='ml-auto text-sm text-gray-500'>\n              {filteredCommands.length} of {Object.keys(CommandDetail).length} commands\n            </span>\n          )}\n        </div>\n\n        {filteredCommands.length === 0 && (\n          <Empty\n            description={\n              enabled === 'Enabled'\n                ? `${finalUserData?.displayName ?? 'This streamer'} has no enabled commands matching your search.`\n                : 'No matching commands found.'\n            }\n            imageStyle={{ height: 60 }}\n          />\n        )}\n\n        <div className='mb-16 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-4'>\n          {filteredCommands.map((key) => (\n            <div id={`command-card-${key}`} key={key}>\n              <CommandsCard\n                readonly\n                id={key}\n                isOpen={openCardKey === key}\n                onClose={() => {\n                  setOpenCardKey(null)\n                }}\n                publicLoading={finalLoading}\n                publicIsEnabled={commands.find((c) => c.command === key)?.isEnabled}\n                command={CommandDetail[key]}\n              />\n            </div>\n          ))}\n        </div>\n\n        {/* Bottom conversion CTA */}\n        <div className='mb-10 rounded-xl border border-gray-700 bg-gray-900 p-8 text-center'>\n          <h2 className='mb-2 text-xl font-bold text-white'>\n            Want these commands for your stream?\n          </h2>\n          <p className='mx-auto mb-5 max-w-md text-sm text-gray-400'>\n            Dotabod adds real-time stats, automated predictions, and smart chat commands to your\n            Dota 2 stream — free to get started.\n          </p>\n          <Link href='/dashboard'>\n            <Button type='primary' size='large'>\n              Set up Dotabod for free\n            </Button>\n          </Link>\n          <p className='mt-4 text-sm'>\n            <Link\n              href='/streamers'\n              className='font-medium text-purple-300 transition-colors hover:text-purple-200'\n            >\n              Browse more Dota 2 streamers →\n            </Link>\n          </p>\n        </div>\n      </Container>\n    </>\n  )\n}",
+            "text": ""
+          }
+        ],
+        "message": "function has a complexity of 85. Maximum allowed is 20.",
         "severity": "error"
       }
     },
@@ -87671,6 +87382,26 @@
         "severity": "error"
       }
     },
+    "a8673da3869103aedb2e5afd976bbd8e692d41c79e9357e96614af4ca9245661": {
+      "count": 1,
+      "summary": {
+        "code": "sonarjs(cognitive-complexity)",
+        "file": "src/pages/api/stripe/create-checkout.ts",
+        "labels": [
+          {
+            "context": {
+              "current": "const createCryptoInvoice = async function createCryptoInvoice(",
+              "next": "params: Omit<CheckoutSessionParams, 'isCryptoPayment' | 'isTrialEligible'>,",
+              "previous": ""
+            },
+            "span": "function",
+            "text": ""
+          }
+        ],
+        "message": "Refactor this function to reduce its Cognitive Complexity from 22 to the 20 allowed.",
+        "severity": "error"
+      }
+    },
     "a86a483c9f56e427020c0eff1f80e264cbb05b83a8e0e39c1a2f6c23a0ec4d5e": {
       "count": 1,
       "summary": {
@@ -87868,26 +87599,6 @@
           }
         ],
         "message": "This makes the for…of loop slow because each await runs one after another, so collect the independent calls & run them together with `await Promise.all(items.map(...))`",
-        "severity": "error"
-      }
-    },
-    "a8a2e6ae005d4e5b75bdbe470cee03852d2f4f1f1416d85f88c26e533b1de201": {
-      "count": 1,
-      "summary": {
-        "code": "eslint(complexity)",
-        "file": "src/pages/[username].tsx",
-        "labels": [
-          {
-            "context": {
-              "current": "const PageContent = ({",
-              "next": "userData: ssrUserData,",
-              "previous": ""
-            },
-            "span": "({\n  userData: ssrUserData,\n  subscriptionInfo: ssrSubscriptionInfo,\n  username: ssrUsername,\n  collection,\n  heroPerformance = [],\n  recentMatches = [],\n}: PageContentProps = {}) => {\n  const [permission, setPermission] = useState('All')\n  const [enabled, setEnabled] = useState('All')\n  const [searchTerm, setSearchTerm] = useState('')\n  const [openCardKey, setOpenCardKey] = useState<string | null>(null)\n  const router = useRouter()\n  const { username } = router.query\n  const { data, loading, error, notFound } = useGetSettingsByUsername()\n\n  const shouldFetchSub = !ssrSubscriptionInfo && typeof username === 'string' && Boolean(username)\n  const { data: subData, isLoading: subLoading } = useSWR<{\n    isPro?: boolean\n    isLifetime?: boolean\n    isGracePeriodPro?: boolean\n    inGracePeriod?: boolean\n  }>(shouldFetchSub ? `/api/subscription/by-username?username=${username}` : null, fetcher)\n\n  const subscriptionInfo = {\n    inGracePeriod: ssrSubscriptionInfo?.inGracePeriod ?? subData?.inGracePeriod ?? false,\n    isGracePeriodPro: ssrSubscriptionInfo?.isGracePeriodPro ?? subData?.isGracePeriodPro ?? false,\n    isLifetime: ssrSubscriptionInfo?.isLifetime ?? subData?.isLifetime ?? false,\n    isPro: ssrSubscriptionInfo?.isPro ?? subData?.isPro ?? false,\n    loading: shouldFetchSub ? subLoading : false,\n  }\n\n  // Use SSR data if available, otherwise fall back to client-side data\n  const finalUserData = ssrUserData ?? data\n  const finalLoading = ssrUserData ? false : loading\n  const profile = finalUserData as {\n    displayName?: string | null\n    name?: string\n    stream_online?: boolean\n    image?: string | null\n    createdAt?: string\n    mmr?: number\n    twitchId?: string | null\n    settings?: { key: string; value: unknown }[]\n    error?: unknown\n  }\n\n  useEffect(() => {\n    // Only redirect to 404 if username exists in query and we've finished loading (for client-side only)\n    if (!ssrUserData && username && !finalLoading && (notFound || profile?.error || error)) {\n      void router.push('/404')\n    }\n  }, [finalLoading, profile, router, notFound, error, username, ssrUserData])\n\n  if (finalLoading || error || !finalUserData) {\n    return (\n      <div className='p-6'>\n        <div className='mb-12 space-y-4'>\n          <div className='flex flex-row items-center space-x-2'>\n            <Skeleton.Avatar active size={80} shape='circle' />\n            <div className='flex-grow'>\n              <div className='flex flex-row items-center space-x-4'>\n                <Skeleton.Button active size='large' shape='round' />\n                <Skeleton.Button active size='small' shape='round' style={{ width: 60 }} />\n              </div>\n              <Skeleton.Input active size='small' style={{ marginTop: 8, width: 200 }} />\n            </div>\n            <div>\n              <div className='flex space-x-2'>\n                <Skeleton.Button active size='default' shape='default' style={{ width: 140 }} />\n                <Skeleton.Button active size='default' shape='default' style={{ width: 160 }} />\n              </div>\n            </div>\n          </div>\n          <Skeleton active paragraph={{ rows: 1 }} />\n        </div>\n\n        <div className='mb-4 flex max-w-full flex-wrap items-baseline gap-2 sm:gap-6'>\n          <Skeleton.Button active size='default' shape='default' style={{ width: 200 }} />\n          <Skeleton.Button active size='default' shape='default' style={{ width: 200 }} />\n          <Skeleton.Input active size='default' style={{ width: 300 }} />\n        </div>\n\n        <div className='mb-10 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-4'>\n          {['sk1', 'sk2', 'sk3', 'sk4', 'sk5', 'sk6', 'sk7', 'sk8'].map((key) => (\n            <div key={key} className='rounded-lg border border-gray-700 p-4'>\n              <Skeleton active paragraph={{ rows: 3 }} />\n            </div>\n          ))}\n        </div>\n      </div>\n    )\n  }\n\n  const commands = profile?.settings\n    ? commandKeys.map((command) => {\n        const commandDetail = CommandDetail[command]\n        const isEnabled = getValueOrDefault(commandDetail.key, profile.settings)\n        return { command, isEnabled: Boolean(isEnabled) }\n      })\n    : []\n\n  const filteredCommands = commandKeys\n    .filter((command) => {\n      const commandDetail = CommandDetail[command]\n      const isEnabled = getValueOrDefault(commandDetail.key, profile.settings)\n      if (enabled === 'Enabled') {\n        return isEnabled === true\n      }\n      if (enabled === 'Disabled') {\n        return isEnabled === false\n      }\n      return true\n    })\n    .filter((command) => {\n      const commandDetail = CommandDetail[command]\n      if (permission === 'Mods') {\n        return commandDetail.allowed === 'mods'\n      }\n      if (permission === 'Viewers') {\n        return commandDetail.allowed === 'all'\n      }\n      return true\n    })\n    .filter((command) => {\n      const keysToSearch = ['alias', 'title', 'description', 'cmd']\n      const commandDetail = CommandDetail[command]\n      return keysToSearch.some((key) => {\n        const value = commandDetail[key as keyof typeof commandDetail] ?? ''\n        if (Array.isArray(value)) {\n          return value.some(\n            (alias) =>\n              alias.toLowerCase().includes(searchTerm) ||\n              `!${alias.toLowerCase()}`.includes(searchTerm),\n          )\n        }\n        return typeof value === 'string' && value.toLowerCase().includes(searchTerm)\n      })\n    })\n\n  const enabledFeaturedCommands = FEATURED_COMMAND_KEYS.filter(\n    (key) => commands.find((c) => c.command === key)?.isEnabled,\n  )\n\n  // Determine what subscription badge to show\n  const getSubscriptionBadge = () => {\n    if (subscriptionInfo.loading) {\n      return null\n    }\n    if (subscriptionInfo.isPro) {\n      if (subscriptionInfo.isGracePeriodPro) {\n        return (\n          <Tooltip title='Using Pro features during free trial period'>\n            <Tag color='blue' className='flex! items-center gap-1 py-0.5'>\n              <CrownIcon size={14} className='inline-block flex-shrink-0' />\n              <span>Free Trial</span>\n            </Tag>\n          </Tooltip>\n        )\n      }\n\n      if (subscriptionInfo.isLifetime) {\n        return (\n          <Tooltip title='Lifetime Pro Subscriber'>\n            <Tag color='gold' className='flex! items-center gap-1 py-0.5'>\n              <CrownIcon size={14} className='inline-block flex-shrink-0' />\n              <span>Lifetime Pro</span>\n            </Tag>\n          </Tooltip>\n        )\n      }\n\n      return (\n        <Tooltip title='Pro Subscriber'>\n          <Tag color='gold' className='flex! items-center gap-1 py-0.5'>\n            <CrownIcon size={14} className='inline-block flex-shrink-0' />\n            <span>Pro</span>\n          </Tag>\n        </Tooltip>\n      )\n    }\n\n    return null\n  }\n\n  return (\n    <>\n      {/* oxlint-disable-next-line nextjs/no-duplicate-head -- conditional render path, only one Head per render */}\n      <Head>\n        <title>{`${finalLoading || !profile?.displayName ? '...' : profile.displayName}'s Dota 2 Commands — Dotabod`}</title>\n        <meta\n          name='description'\n          content={`Chat commands available in ${profile?.displayName ?? 'this streamer'}'s Twitch channel via Dotabod.`}\n        />\n        {username && typeof username === 'string' && (\n          <link rel='canonical' href={`https://dotabod.com/${username}`} />\n        )}\n        <meta\n          name='robots'\n          content={username === '[username]' ? 'noindex, nofollow' : 'index, follow'}\n        />\n      </Head>\n\n      {/* Full-width hero */}\n      <div className='relative border-b border-gray-700/50 bg-gradient-to-br from-gray-950 to-gray-800'>\n        <Container className='py-10 sm:py-14'>\n          <div className='flex flex-col gap-6 sm:flex-row sm:flex-wrap sm:items-start sm:gap-10 lg:flex-nowrap'>\n            {/* Avatar with live ring */}\n            <div className='relative flex-shrink-0 self-start'>\n              <div\n                className={`absolute -inset-1.5 rounded-full ${\n                  profile?.stream_online ? 'animate-pulse bg-red-500/30' : 'bg-gray-600/10'\n                }`}\n              />\n              <img\n                onError={(e) => {\n                  e.currentTarget.src = '/images/hero/default.png'\n                }}\n                src={profile?.image ?? '/images/hero/default.png'}\n                alt='Profile'\n                width={100}\n                height={100}\n                className='relative rounded-full ring-2 ring-gray-700'\n              />\n              {profile?.stream_online && (\n                <span className='absolute -bottom-1 left-1/2 -translate-x-1/2 rounded-full bg-red-600 px-2 py-px text-[10px] font-bold tracking-wide text-white uppercase'>\n                  Live\n                </span>\n              )}\n            </div>\n\n            {/* Identity, stats, CTAs */}\n            <div className='min-w-0 flex-grow'>\n              <div className='mb-1 flex flex-wrap items-center gap-2'>\n                <h1 className='text-3xl font-bold text-white sm:text-4xl'>\n                  {finalLoading || !profile?.displayName ? 'Loading...' : profile.displayName}\n                </h1>\n                {!profile?.stream_online && (\n                  <span className='rounded-md bg-gray-700 px-2 py-0.5 text-xs text-gray-400'>\n                    Offline\n                  </span>\n                )}\n                {getSubscriptionBadge()}\n              </div>\n\n              <div className='mb-6 flex flex-wrap gap-x-5 gap-y-1 text-sm text-gray-400'>\n                {profile?.mmr !== null && profile?.mmr !== undefined && profile.mmr > 0 && (\n                  <span>⚔ {profile.mmr.toLocaleString()} MMR</span>\n                )}\n                <ProfileWinLossCounter twitchId={profile?.twitchId} />\n                <span>\n                  Using Dotabod since{' '}\n                  {finalLoading || !profile?.createdAt\n                    ? '...'\n                    : new Date(profile.createdAt).toLocaleDateString('en-US', {\n                        month: 'long',\n                        year: 'numeric',\n                      })}\n                </span>\n                {!finalLoading && commands.length > 0 && (\n                  <span>{commands.filter((c) => c.isEnabled).length} commands active</span>\n                )}\n              </div>\n\n              <div className='flex flex-wrap gap-3'>\n                <Link\n                  target='_blank'\n                  href={profile ? `https://twitch.tv/${profile.name}` : ''}\n                  passHref\n                >\n                  <Button\n                    size='large'\n                    icon={<ExternalLinkIcon size={16} />}\n                    className='flex items-center'\n                  >\n                    Watch on Twitch\n                  </Button>\n                </Link>\n                <Link\n                  href={createGiftLink(\n                    ssrUsername ?? (typeof username === 'string' ? username : ''),\n                  )}\n                  passHref\n                >\n                  <Button\n                    type='primary'\n                    size='large'\n                    icon={<GiftIcon size={16} />}\n                    className='flex items-center'\n                  >\n                    Gift Subscription\n                  </Button>\n                </Link>\n                <Link\n                  href={getProfileRoute(\n                    ssrUsername ?? (typeof username === 'string' ? username : undefined),\n                    '/matches',\n                  )}\n                  passHref\n                >\n                  <Button\n                    size='large'\n                    icon={<BarChart3Icon size={16} />}\n                    className='flex items-center'\n                  >\n                    Match history\n                  </Button>\n                </Link>\n              </div>\n            </div>\n\n            {collection && collection.count > 0 ? (\n              <FannedHand\n                username={ssrUsername ?? (typeof username === 'string' ? username : '')}\n                collection={collection}\n              />\n            ) : (\n              <CollectionTeaser\n                username={ssrUsername ?? (typeof username === 'string' ? username : '')}\n                name={profile?.displayName ?? profile?.name ?? 'this streamer'}\n              />\n            )}\n          </div>\n        </Container>\n      </div>\n\n      {/* Page content */}\n      <Container className='py-8'>\n        <ProfileMatchOverview\n          heroPerformance={heroPerformance}\n          recentMatches={recentMatches}\n          username={ssrUsername ?? (typeof username === 'string' ? username : '')}\n        />\n\n        {/* Featured commands strip */}\n        {!finalLoading && enabledFeaturedCommands.length > 0 && (\n          <div className='mb-10'>\n            <p className='mb-3 text-xs font-semibold tracking-widest text-gray-500 uppercase'>\n              Popular commands\n            </p>\n            <div className='-mx-1 flex gap-3 overflow-x-auto px-1 pb-2'>\n              {enabledFeaturedCommands.map((key) => (\n                <button\n                  key={key}\n                  type='button'\n                  onClick={() => {\n                    setOpenCardKey(key)\n                    setTimeout(() => {\n                      document\n                        .getElementById(`command-card-${key}`)\n                        ?.scrollIntoView({ behavior: 'smooth', block: 'center' })\n                    }, 50)\n                  }}\n                  className='w-48 flex-shrink-0 cursor-pointer rounded-lg border border-gray-700 bg-gray-900/80 px-4 py-3 text-left transition-colors hover:border-purple-500 hover:bg-gray-900'\n                >\n                  <div className='mb-1 font-mono text-sm font-semibold text-purple-400'>\n                    {CommandDetail[key].cmd}\n                  </div>\n                  <div className='line-clamp-2 text-xs text-gray-400'>\n                    {CommandDetail[key].description}\n                  </div>\n                </button>\n              ))}\n            </div>\n          </div>\n        )}\n\n        {/* Filter bar */}\n        <div className='mb-6 flex flex-wrap items-center gap-3'>\n          <Segmented\n            value={enabled}\n            onChange={(v) => {\n              setEnabled(v)\n            }}\n            options={['All', 'Enabled', 'Disabled']}\n          />\n          <Segmented\n            value={permission}\n            onChange={(v) => {\n              setPermission(v)\n            }}\n            options={['All', 'Mods', 'Viewers']}\n          />\n          <Input\n            placeholder='Search commands...'\n            value={searchTerm}\n            maxLength={200}\n            style={{ width: 260 }}\n            onChange={(e) => {\n              setSearchTerm(e.target.value.toLowerCase())\n            }}\n          />\n          {!finalLoading && (\n            <span className='ml-auto text-sm text-gray-500'>\n              {filteredCommands.length} of {Object.keys(CommandDetail).length} commands\n            </span>\n          )}\n        </div>\n\n        {filteredCommands.length === 0 && (\n          <Empty\n            description={\n              enabled === 'Enabled'\n                ? `${finalUserData?.displayName ?? 'This streamer'} has no enabled commands matching your search.`\n                : 'No matching commands found.'\n            }\n            imageStyle={{ height: 60 }}\n          />\n        )}\n\n        <div className='mb-16 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-4'>\n          {filteredCommands.map((key) => (\n            <div id={`command-card-${key}`} key={key}>\n              <CommandsCard\n                readonly\n                id={key}\n                isOpen={openCardKey === key}\n                onClose={() => {\n                  setOpenCardKey(null)\n                }}\n                publicLoading={finalLoading}\n                publicIsEnabled={commands.find((c) => c.command === key)?.isEnabled}\n                command={CommandDetail[key]}\n              />\n            </div>\n          ))}\n        </div>\n\n        {/* Bottom conversion CTA */}\n        <div className='mb-10 rounded-xl border border-gray-700 bg-gray-900 p-8 text-center'>\n          <h2 className='mb-2 text-xl font-bold text-white'>\n            Want these commands for your stream?\n          </h2>\n          <p className='mx-auto mb-5 max-w-md text-sm text-gray-400'>\n            Dotabod adds real-time stats, automated predictions, and smart chat commands to your\n            Dota 2 stream — free to get started.\n          </p>\n          <Link href='/dashboard'>\n            <Button type='primary' size='large'>\n              Set up Dotabod for free\n            </Button>\n          </Link>\n          <p className='mt-4 text-sm'>\n            <Link\n              href='/streamers'\n              className='font-medium text-purple-300 transition-colors hover:text-purple-200'\n            >\n              Browse more Dota 2 streamers →\n            </Link>\n          </p>\n        </div>\n      </Container>\n    </>\n  )\n}",
-            "text": ""
-          }
-        ],
-        "message": "function has a complexity of 85. Maximum allowed is 20.",
         "severity": "error"
       }
     },
@@ -89784,6 +89495,26 @@
           }
         ],
         "message": "Async function used in a context where a void function is expected.",
+        "severity": "error"
+      }
+    },
+    "acc8a8244670f3b5dba08cc1ed3566bc304a3569a30355e73c899055f0054598": {
+      "count": 1,
+      "summary": {
+        "code": "typescript(no-unsafe-argument)",
+        "file": "src/__tests__/pages/api/hubspot/visitor-token.test.ts",
+        "labels": [
+          {
+            "context": {
+              "current": "vi.mocked(fetch).mockResolvedValue(tokenOk())",
+              "next": "vi.mocked(syncHubSpotContact).mockResolvedValue(true)",
+              "previous": "vi.mocked(getSubscription).mockResolvedValue(anyVal({ status: 'ACTIVE', tier: 'PRO' }))"
+            },
+            "span": "tokenOk()",
+            "text": ""
+          }
+        ],
+        "message": "Unsafe argument of type any assigned to a parameter of type Response.",
         "severity": "error"
       }
     },
@@ -93510,6 +93241,26 @@
         "severity": "error"
       }
     },
+    "b4a3de8b99ecf7cdeb8522071b9097cd3cbf0a018865a8750b51e3e5c4afd8d5": {
+      "count": 1,
+      "summary": {
+        "code": "typescript(consistent-return)",
+        "file": "src/lib/hooks/use-socket.tsx",
+        "labels": [
+          {
+            "context": {
+              "current": "return () => {",
+              "next": "clearInterval(connectionMonitor)",
+              "previous": "// Clean up"
+            },
+            "span": "return () => {\n      clearInterval(connectionMonitor)\n      clearInterval(diagnosticHeartbeat)\n      // Clear all message timeouts\n      messageTimeoutsRef.current.forEach((timeoutId) => {\n        clearTimeout(timeoutId)\n      })\n      messageTimeoutsRef.current.clear()\n\n      // Don't disconnect the socket on every effect cleanup\n      // Only clean up event handlers\n      socket?.off('connect')\n      socket?.off('connect_error')\n      socket?.off('disconnect')\n      socket?.off('DATA_buildings')\n      socket?.off('DATA_heroes')\n      socket?.off('DATA_couriers')\n      socket?.off('DATA_creeps')\n      socket?.off('DATA_hero_units')\n      socket?.off('STATUS')\n      socket?.off('requestHeroData')\n      socket?.off('requestMatchData')\n      socket?.off('block')\n      socket?.off('paused')\n      socket?.off('notable-players')\n      socket?.off('aegis-picked-up')\n      socket?.off('chatMessage')\n      socket?.off('roshan-killed')\n      socket?.off('auth_error')\n      socket?.off('refresh-settings')\n      activeSocket.off('diagnostic-overlay-probe')\n      socket?.off('channelPollOrBet')\n      socket?.off('update-medal')\n      socket?.off('update-wl')\n      socket?.off('update-radiant-win-chance')\n      socket?.off('refresh')\n    }",
+            "text": ""
+          }
+        ],
+        "message": "Function expected no return value.",
+        "severity": "error"
+      }
+    },
     "b4b36b2281bd01be2f9eb2cec7818ab93b6e25914190da630f0b172183ce2cf3": {
       "count": 1,
       "summary": {
@@ -96733,35 +96484,6 @@
         "severity": "error"
       }
     },
-    "bc30c5567f8730eea65b51722e3b6f5025d29590f469d2bd9500552cbafe1f5c": {
-      "count": 1,
-      "summary": {
-        "code": "eslint(no-shadow)",
-        "file": "src/pages/api/stripe/create-checkout.ts",
-        "labels": [
-          {
-            "context": {
-              "current": "const customerId = await ensureCustomer(session.user, tx)",
-              "next": "const subscriptionData = await getSubscription(session.user.id, tx)",
-              "previous": "async (tx) => {"
-            },
-            "span": "customerId",
-            "text": "'customerId' is declared here"
-          },
-          {
-            "context": {
-              "current": "const { customerId, subscriptionData } = await prisma.$transaction(",
-              "next": "async (tx) => {",
-              "previous": "// And any nested non-tx prisma write deadlocks the pool."
-            },
-            "span": "customerId",
-            "text": "shadowed declaration is here"
-          }
-        ],
-        "message": "'customerId' is already declared in the upper scope.",
-        "severity": "error"
-      }
-    },
     "bc31d0bf0acc82be096f40f098c2806ee5adc099e717c2fcf70564f30961c89c": {
       "count": 1,
       "summary": {
@@ -99418,6 +99140,35 @@
           }
         ],
         "message": "Async function has no `await` expression.",
+        "severity": "error"
+      }
+    },
+    "c1c7956520deb5e10fd5ffe711dc7afb2ab6f46d660dd2d2ad706a7a48406c56": {
+      "count": 1,
+      "summary": {
+        "code": "eslint(no-use-before-define)",
+        "file": "src/pages/api/stripe/create-checkout.ts",
+        "labels": [
+          {
+            "context": {
+              "current": "const customer = await ensureCustomer(session.user, tx)",
+              "next": "const currentSubscription = await getSubscription(session.user.id, tx)",
+              "previous": "async (tx) => {"
+            },
+            "span": "ensureCustomer",
+            "text": "used here"
+          },
+          {
+            "context": {
+              "current": "const ensureCustomer = async function ensureCustomer(",
+              "next": "user: {",
+              "previous": ""
+            },
+            "span": "ensureCustomer",
+            "text": "defined here"
+          }
+        ],
+        "message": "'ensureCustomer' was used before it was defined.",
         "severity": "error"
       }
     },
@@ -105345,6 +105096,26 @@
         "severity": "error"
       }
     },
+    "cc53c49efe93f6d24b759704d628fbf4b8944dab1bedfe6918a377a81f745ed7": {
+      "count": 1,
+      "summary": {
+        "code": "eslint(complexity)",
+        "file": "src/pages/api/stripe/create-checkout.ts",
+        "labels": [
+          {
+            "context": {
+              "current": "const createCryptoInvoice = async function createCryptoInvoice(",
+              "next": "params: Omit<CheckoutSessionParams, 'isCryptoPayment' | 'isTrialEligible'>,",
+              "previous": ""
+            },
+            "span": "async function createCryptoInvoice(\n  params: Omit<CheckoutSessionParams, 'isCryptoPayment' | 'isTrialEligible'>,\n): Promise<string> {\n  const {\n    customerId,\n    priceId,\n    isRecurring,\n    isLifetime,\n    subscriptionData,\n    userId,\n    email,\n    name,\n    image,\n    locale,\n    twitchId,\n  } = params\n\n  // Cancel any pending crypto invoices if this is an upgrade\n  if (subscriptionData?.stripePriceId) {\n    try {\n      const existingSubscription = await prisma.subscription.findFirst({\n        select: { metadata: true },\n        where: {\n          NOT: { status: 'CANCELED' },\n          stripeCustomerId: customerId,\n          userId,\n        },\n      })\n\n      const metadata = (existingSubscription?.metadata as Record<string, unknown>) || {}\n      const renewalInvoiceId = metadata.renewalInvoiceId as string\n\n      if (renewalInvoiceId) {\n        console.log(`Canceling pending invoice ${renewalInvoiceId} for user ${userId}`)\n        try {\n          await stripe.invoices.voidInvoice(renewalInvoiceId)\n        } catch {\n          try {\n            const invoice = await stripe.invoices.retrieve(renewalInvoiceId)\n            if (invoice.status === 'open') {\n              await stripe.invoices.markUncollectible(renewalInvoiceId)\n            }\n          } catch (markError) {\n            console.error(`Failed to handle invoice ${renewalInvoiceId}:`, markError)\n          }\n        }\n      }\n    } catch (error) {\n      console.error('Error canceling pending invoices:', error)\n    }\n  }\n\n  const { getCurrentPeriod } = await import('@/utils/subscription')\n  const pricePeriod = getCurrentPeriod(priceId)\n  const price = await stripe.prices.retrieve(priceId)\n\n  if (!price.unit_amount) {\n    throw new Error('Price has no unit amount')\n  }\n\n  const dueDate = new Date()\n  dueDate.setDate(dueDate.getDate() + 7)\n\n  const invoiceParams: Stripe.InvoiceCreateParams = {\n    collection_method: 'send_invoice',\n    customer: customerId,\n    due_date: Math.floor(dueDate.getTime() / 1000),\n    metadata: {\n      email,\n      image,\n      isCryptoPayment: 'true',\n      isNewSubscription: isRecurring && !subscriptionData?.stripeSubscriptionId ? 'true' : 'false',\n      isUpgradeToLifetime: isLifetime && subscriptionData?.stripeSubscriptionId ? 'true' : 'false',\n      locale,\n      name,\n      paymentProvider: 'nowpayments',\n      previousSubscriptionId: subscriptionData?.stripeSubscriptionId ?? '',\n      pricePeriod,\n      stripePriceId: priceId,\n      twitchId,\n      userId,\n    },\n    payment_settings: {\n      payment_method_types: [],\n    },\n  }\n\n  const stripeInvoice = await stripe.invoices.create(invoiceParams)\n  if (!stripeInvoice?.id) {\n    throw new Error('Stripe invoice creation failed')\n  }\n\n  await stripe.invoiceItems.create({\n    customer: customerId,\n    invoice: stripeInvoice.id,\n    price_data: {\n      currency: price.currency,\n      product: price.product as string,\n      unit_amount: price.unit_amount,\n    },\n  })\n\n  const finalized = await stripe.invoices.finalizeInvoice(stripeInvoice.id, {\n    auto_advance: false,\n  })\n\n  const { url, nowPaymentsId } = await createAndStoreCryptoInvoice({\n    metadata: { pricePeriod, stripePriceId: priceId },\n    orderDescription: `Dotabod ${pricePeriod} subscription`,\n    stripeInvoice: finalized,\n    userId,\n  })\n\n  await stripe.invoices.update(stripeInvoice.id, {\n    metadata: {\n      ...invoiceParams.metadata,\n      nowpayments_invoice_id: nowPaymentsId,\n      nowpayments_invoice_url: url,\n    },\n  })\n\n  return url\n}",
+            "text": ""
+          }
+        ],
+        "message": "async function `createCryptoInvoice` has a complexity of 21. Maximum allowed is 20.",
+        "severity": "error"
+      }
+    },
     "cc6066ac4be8bc8c4cf549d0e2b85c748c465ceedc9eaf3d8c9decef06b33d27": {
       "count": 1,
       "summary": {
@@ -110659,26 +110430,6 @@
           }
         ],
         "message": "Mocked modules must be dynamic imported.",
-        "severity": "error"
-      }
-    },
-    "d668d9980fe04f7b6ee07005ff5dbac891c2388321cc8a3bbfd781ac3c62555f": {
-      "count": 1,
-      "summary": {
-        "code": "eslint(complexity)",
-        "file": "src/pages/api/stripe/create-checkout.ts",
-        "labels": [
-          {
-            "context": {
-              "current": "const createCheckoutSession = async function createCheckoutSession(",
-              "next": "params: CheckoutSessionParams,",
-              "previous": ""
-            },
-            "span": "async function createCheckoutSession(\n  params: CheckoutSessionParams,\n): Promise<string> {\n  const {\n    customerId,\n    priceId,\n    isRecurring,\n    isLifetime,\n    subscriptionData,\n    userId,\n    email,\n    name,\n    image,\n    locale,\n    twitchId,\n    referer,\n    isGift,\n    isCryptoPayment,\n  } = params\n\n  // If this is a crypto payment, use the NOWPayments hosted invoice flow\n  if (isCryptoPayment) {\n    return await createCryptoInvoice({\n      customerId,\n      email,\n      image,\n      isLifetime,\n      isRecurring,\n      locale,\n      name,\n      priceId,\n      referer,\n      subscriptionData,\n      twitchId,\n      userId,\n    })\n  }\n\n  // Handle regular Stripe checkout\n  const baseUrl = process.env.NEXTAUTH_URL ?? ''\n\n  // Calculate trial period based on grace period\n  const now = new Date()\n\n  // Simplified trial period logic\n  let trialDays = 0\n\n  if (isGift) {\n    // No trial for gift purchases\n    trialDays = 0\n  } else if (isInGracePeriod()) {\n    // If we're in the grace period, use days until grace period ends as trial\n    trialDays = Math.ceil((GRACE_PERIOD_END.getTime() - now.getTime()) / (1000 * 60 * 60 * 24))\n  } else if (isRecurring) {\n    // Standard trial for new self-subscriptions\n    trialDays = 14\n  }\n\n  // Build success URL with simplified parameters\n  const successUrl = `${baseUrl || 'https://dotabod.com'}/dashboard?paid=true&crypto=false&trial=${isRecurring && trialDays > 0}&trialDays=${trialDays}`\n\n  const cancelUrl = referer?.includes('/dashboard')\n    ? `${baseUrl || 'https://dotabod.com'}/dashboard/billing?paid=false`\n    : `${baseUrl || 'https://dotabod.com'}/?paid=false`\n\n  const session = await stripe.checkout.sessions.create({\n    allow_promotion_codes: true,\n    cancel_url: cancelUrl,\n    customer: customerId,\n    line_items: [{ price: priceId, quantity: 1 }],\n    metadata: {\n      email,\n      image,\n      isCryptoPayment: 'false',\n      isGift: isGift ? 'true' : 'false',\n      isNewSubscription: isRecurring && !subscriptionData?.stripeSubscriptionId ? 'true' : 'false',\n      isUpgradeToLifetime: isLifetime && subscriptionData?.stripeSubscriptionId ? 'true' : 'false',\n      locale,\n      name,\n      previousSubscriptionId: subscriptionData?.stripeSubscriptionId ?? '',\n      twitchId,\n      userId,\n    },\n    mode: isRecurring ? 'subscription' : 'payment',\n    subscription_data: isRecurring\n      ? {\n          ...(trialDays > 0 ? { trial_period_days: trialDays } : {}),\n          trial_settings: {\n            end_behavior: { missing_payment_method: 'cancel' },\n          },\n        }\n      : undefined,\n    success_url: successUrl,\n  })\n\n  return session.url ?? ''\n}",
-            "text": ""
-          }
-        ],
-        "message": "async function `createCheckoutSession` has a complexity of 25. Maximum allowed is 20.",
         "severity": "error"
       }
     },
@@ -117742,6 +117493,26 @@
         "severity": "error"
       }
     },
+    "e346a4ff400fd8a669e51ccf3eb434a73a63f493822769ab1b73e0fe85c1ab56": {
+      "count": 1,
+      "summary": {
+        "code": "anti-slop(require-safety-comment-for-type-assertion)",
+        "file": "src/pages/api/stripe/create-checkout.ts",
+        "labels": [
+          {
+            "context": {
+              "current": "const { priceId, paymentMethod } = (await req.body) as CheckoutRequestBody",
+              "next": "if (!priceId) {",
+              "previous": "// Parse and validate request body"
+            },
+            "span": "(await req.body) as CheckoutRequestBody",
+            "text": ""
+          }
+        ],
+        "message": "This type assertion has no `SAFETY:` justification. State the checked invariant immediately before the assertion or its containing statement.",
+        "severity": "error"
+      }
+    },
     "e3496ef19a286cdb701f940310b5796f3e43890effa73c6c34976beafed320a8": {
       "count": 1,
       "summary": {
@@ -120998,26 +120769,6 @@
           }
         ],
         "message": "Unexpected nullable string value in conditional. Please handle the nullish and empty string cases explicitly.",
-        "severity": "error"
-      }
-    },
-    "e9500f5499d7e2a9028105dd26e224b649bbd39ced687d42706b637c29cc0a4b": {
-      "count": 1,
-      "summary": {
-        "code": "eslint(no-await-in-loop)",
-        "file": "scripts/backfill-hubspot-contacts.ts",
-        "labels": [
-          {
-            "context": {
-              "current": "await syncUser(user)",
-              "next": "}",
-              "previous": "const user = users[(cursor += 1)]"
-            },
-            "span": "await",
-            "text": ""
-          }
-        ],
-        "message": "Unexpected `await` inside a loop.",
         "severity": "error"
       }
     },
@@ -131751,35 +131502,6 @@
         "severity": "error"
       }
     },
-    "fd87dc29afec9a92358acc365a5142fe403476a2300310e6cc117d858787a15a": {
-      "count": 1,
-      "summary": {
-        "code": "eslint(no-shadow)",
-        "file": "src/pages/api/stripe/create-checkout.ts",
-        "labels": [
-          {
-            "context": {
-              "current": "const subscriptionData = await getSubscription(session.user.id, tx)",
-              "next": "return { customerId, subscriptionData }",
-              "previous": "const customerId = await ensureCustomer(session.user, tx)"
-            },
-            "span": "subscriptionData",
-            "text": "'subscriptionData' is declared here"
-          },
-          {
-            "context": {
-              "current": "const { customerId, subscriptionData } = await prisma.$transaction(",
-              "next": "async (tx) => {",
-              "previous": "// And any nested non-tx prisma write deadlocks the pool."
-            },
-            "span": "subscriptionData",
-            "text": "shadowed declaration is here"
-          }
-        ],
-        "message": "'subscriptionData' is already declared in the upper scope.",
-        "severity": "error"
-      }
-    },
     "fd8a6c6fd717b5e0ecf9cea77f3dbce5eeea5cd5e780a8c4c5c7fd1e3b4136c2": {
       "count": 1,
       "summary": {
@@ -133470,6 +133192,7 @@
           "src/lib/dev-consts.ts",
           "src/lib/diagnostics/diagnose-setup.test.ts",
           "src/lib/diagnostics/diagnose-setup.ts",
+          "src/lib/diagnostics/report-overlay-page.ts",
           "src/lib/dota-finding-match-label.ts",
           "src/lib/feature-flags.ts",
           "src/lib/fetcher.tsx",
@@ -133520,6 +133243,7 @@
           "src/lib/setup-signal-keys.ts",
           "src/lib/stripe-server.ts",
           "src/lib/stripe.ts",
+          "src/lib/stripe/checkout-prices.ts",
           "src/lib/stripe/checkout-redirect.ts",
           "src/lib/stripe/gift-checkout-request.ts",
           "src/lib/stripe/gift-checkout.ts",
@@ -133685,8 +133409,12 @@
         "name": "app",
         "resolvedConfigSha256": "c0c208cf8ff15b7a20a4ff6c86712ca2289f5ddd5cc522b89a67ca1704f34fa1",
         "scope": {
-          "ignorePatterns": ["supabase/functions/**"],
-          "paths": ["."]
+          "ignorePatterns": [
+            "supabase/functions/**"
+          ],
+          "paths": [
+            "."
+          ]
         }
       },
       {
@@ -133709,7 +133437,9 @@
         "resolvedConfigSha256": "6c6c97b8453def202543b9830ada155f95f1a1375685319dec3501f5c65e59a1",
         "scope": {
           "ignorePatterns": [],
-          "paths": ["supabase/functions"]
+          "paths": [
+            "supabase/functions"
+          ]
         }
       }
     ],

--- a/tools/quality/oxlint-baseline.json
+++ b/tools/quality/oxlint-baseline.json
@@ -133409,12 +133409,8 @@
         "name": "app",
         "resolvedConfigSha256": "c0c208cf8ff15b7a20a4ff6c86712ca2289f5ddd5cc522b89a67ca1704f34fa1",
         "scope": {
-          "ignorePatterns": [
-            "supabase/functions/**"
-          ],
-          "paths": [
-            "."
-          ]
+          "ignorePatterns": ["supabase/functions/**"],
+          "paths": ["."]
         }
       },
       {
@@ -133437,9 +133433,7 @@
         "resolvedConfigSha256": "6c6c97b8453def202543b9830ada155f95f1a1375685319dec3501f5c65e59a1",
         "scope": {
           "ignorePatterns": [],
-          "paths": [
-            "supabase/functions"
-          ]
+          "paths": ["supabase/functions"]
         }
       }
     ],


### PR DESCRIPTION
Returning customers could receive another Stripe trial, unknown active Stripe prices could default to Pro, and inactive subscription rows could be labeled as paid in HubSpot.

- Allow checkout only for the configured monthly, annual, and lifetime USD prices, then verify each Stripe price is active and has the expected billing type and interval.
- Grant the 14-day card trial only when neither the local database nor Stripe has prior subscription history; omit the trial if the Stripe history lookup fails.
- Prevent regular checkout requests from supplying gift metadata, and fail unknown price-to-tier mappings closed while preserving internal price-less Pro records.
- Map HubSpot labels from explicit subscription statuses so inactive rows become Free while trialing and past-due accounts retain distinct labels.
- Fix the one-time HubSpot backfill cursor and success accounting, and keep the scheduled Supabase mapper aligned with the application helper.
- Add focused regression coverage and remove the resolved Oxlint baseline entries.
