### PR TITLE
Fix translation overlay messages persisting after rerenders

### DIFF
--- a/src/__tests__/lib/hooks/use-socket.test.tsx
+++ b/src/__tests__/lib/hooks/use-socket.test.tsx
@@ -338,4 +338,42 @@ describe(useSocket, () => {
       vi.unstubAllGlobals()
     }
   })
+
+  it('removes translated chat messages after ten seconds across rerenders', () => {
+    vi.useFakeTimers()
+    type SocketProps = Parameters<typeof useSocket>[0]
+    const setChatMessages = vi.fn<SocketProps['setChatMessages']>()
+    const socketProps: SocketProps = {
+      setAegis: vi.fn<SocketProps['setAegis']>(),
+      setBetData: vi.fn<SocketProps['setBetData']>(),
+      setBlock: vi.fn<SocketProps['setBlock']>(),
+      setChatMessages,
+      setConnected: vi.fn<SocketProps['setConnected']>(),
+      setNotablePlayers: vi.fn<SocketProps['setNotablePlayers']>(),
+      setPaused: vi.fn<SocketProps['setPaused']>(),
+      setPollData: vi.fn<SocketProps['setPollData']>(),
+      setRadiantWinChance: vi.fn<SocketProps['setRadiantWinChance']>(),
+      setRankImageDetails: vi.fn<SocketProps['setRankImageDetails']>(),
+      setRoshan: vi.fn<SocketProps['setRoshan']>(),
+      setWL: vi.fn<SocketProps['setWL']>(),
+    }
+
+    const { rerender } = renderHook(() => {
+      useSocket(socketProps)
+    })
+
+    act(() => {
+      socketState.handlers.get('chatMessage')?.({ message: 'Translated message', timestamp: 1 })
+    })
+    expect(setChatMessages).toHaveBeenCalledOnce()
+
+    socketState.mutate = socketState.dispatch
+    rerender()
+
+    act(() => {
+      vi.advanceTimersByTime(10_000)
+    })
+
+    expect(setChatMessages).toHaveBeenCalledTimes(2)
+  })
 })

--- a/src/lib/hooks/use-socket.tsx
+++ b/src/lib/hooks/use-socket.tsx
@@ -157,6 +157,11 @@ export const useSocket = ({
   // Can pass any key here, we just want mutate() function on `api/settings`
   const { mutate } = useUpdateSetting(Settings.commandWL)
 
+  const refreshSettingsRef = useRef(mutate)
+  useEffect(() => {
+    refreshSettingsRef.current = mutate
+  }, [mutate])
+
   // Ref to store timeout IDs for chat message cleanup
   const messageTimeoutsRef = useRef<Map<string, NodeJS.Timeout>>(new Map())
 
@@ -345,7 +350,7 @@ export const useSocket = ({
     socket.on('connect', () => {
       console.log('Socket connected event fired')
       updateLastReceived()
-      mutate()
+      refreshSettingsRef.current()
       setConnected(true)
     })
     socket.on('connect_error', (error) => {
@@ -359,7 +364,7 @@ export const useSocket = ({
 
     socket.on('refresh-settings', (_key: typeof Settings) => {
       updateLastReceived()
-      mutate()
+      refreshSettingsRef.current()
     })
 
     activeSocket.on('diagnostic-overlay-probe', () => {
@@ -407,7 +412,7 @@ export const useSocket = ({
 
     socket.on('refresh', () => {
       updateLastReceived()
-      mutate()
+      refreshSettingsRef.current()
     })
 
     // Clean up
@@ -450,7 +455,6 @@ export const useSocket = ({
     }
   }, [
     dispatch,
-    mutate,
     setAegis,
     setBetData,
     setBlock,


### PR DESCRIPTION
## Summary

- keep settings refresh callbacks from restarting the overlay socket lifecycle
- preserve translated-message expiration timers across overlay rerenders
- cover messages disappearing after 10 seconds even when the refresh callback identity changes

## Cause

The socket effect depended on a newly created settings refresh callback. Receiving a translated message rerendered the overlay, which ran effect cleanup and canceled the message removal timer while leaving the message visible.